### PR TITLE
de-duplicate genes, collapse file/type

### DIFF
--- a/R/annoFuseData_update.R
+++ b/R/annoFuseData_update.R
@@ -1,5 +1,6 @@
 # Read in the necessary data
-ann <- read_tsv("../inst/extdata/genelistreference.txt")
+ann <- read_tsv("../inst/extdata/genelistreference.txt") %>%
+  select(-classification)
 onco_tsg <- read_tsv("../inst/extdata/cancerGeneList.tsv") %>%
   dplyr::rename(Gene_Symbol = `Hugo Symbol`) %>%
   mutate(classification = case_when(
@@ -9,20 +10,22 @@ onco_tsg <- read_tsv("../inst/extdata/cancerGeneList.tsv") %>%
     TRUE ~ NA_character_
   )) %>%
   filter(!is.na(classification))
+  
 
 # Function to add classification, update file column, and add missing genes
-update_ann_rm <- function(ann_rm, onco_tsg) {
+update_ann_rm <- function(gene_file, onco_tsg) {
   # Filter out the specified file and clean the file and type columns
-  ann_rm <- ann_rm %>%
-    filter(file != "allOnco_Feb2017.tsv") %>%
+  gene_file <- gene_file %>%
+    dplyr::filter(file != "allOnco_Feb2017.tsv") %>%
     mutate(file = gsub(", allOnco_Feb2017.tsv|allOnco_Feb2017.tsv, ", "", file),
            type = gsub(", Oncogene|Oncogene, ", "", type))
   
   # Create a lookup table from onco_tsg
-  classification_lookup <- onco_tsg %>% select(Gene_Symbol, classification)
+  classification_lookup <- onco_tsg %>% 
+    select(Gene_Symbol, classification)
   
   # Perform a full join to ensure all genes from onco_tsg are included
-  combined_data <- full_join(ann_rm, classification_lookup, by = c("Gene_Symbol"))
+  combined_data <- full_join(gene_file, classification_lookup, by = c("Gene_Symbol"))
   
   # Update the type and file columns
   combined_data <- combined_data %>%
@@ -38,8 +41,8 @@ update_ann_rm <- function(ann_rm, onco_tsg) {
       # Ensure type contains unique classifications
       type = paste(unique(trimws(unlist(strsplit(type, ", ")))), collapse = ", "),
       # Add "OncoKB" to file if not already present
-      file = ifelse(is.na(file), "OncoKBv20240704", 
-                    ifelse(!grepl("OncoKBv20240704", file), 
+      file = ifelse(is.na(file) & Gene_Symbol %in% classification_lookup$Gene_Symbol, "OncoKBv20240704", 
+                    ifelse(!grepl("OncoKBv20240704", file) & Gene_Symbol %in% classification_lookup$Gene_Symbol, 
                            paste0(file, ifelse(file == "", "", ", "), "OncoKBv20240704"), 
                            file))
     ) %>%
@@ -51,10 +54,6 @@ update_ann_rm <- function(ann_rm, onco_tsg) {
 
 # Apply the function to ann_rm
 ann_rm <- update_ann_rm(ann, onco_tsg) %>%
+  select(-classification) %>%
   arrange(Gene_Symbol) %>%
   write_tsv("../inst/extdata/genelistreference.txt")
-
-as.data.frame(table(ann_rm$type))
-
-
-setdiff(ann$Gene_Symbol, ann_rm$Gene_Symbol)

--- a/R/annoFuseData_update.R
+++ b/R/annoFuseData_update.R
@@ -54,6 +54,11 @@ update_ann_rm <- function(gene_file, onco_tsg) {
 
 # Apply the function to ann_rm
 ann_rm <- update_ann_rm(ann, onco_tsg) %>%
+  group_by(Gene_Symbol, classification) %>%
+  mutate(file = case_when(is.na(classification) ~ gsub(", OncoKBv20240704", "", file), 
+                          TRUE ~ file)) %>%
+  reframe(type = paste(unique(trimws(unlist(strsplit(type, ", ")))), collapse = ", "),
+          file = paste(unique(trimws(unlist(strsplit(file, ", ")))), collapse = ", ")) %>%
   select(-classification) %>%
   arrange(Gene_Symbol) %>%
   write_tsv("../inst/extdata/genelistreference.txt")

--- a/inst/extdata/genelistreference.txt
+++ b/inst/extdata/genelistreference.txt
@@ -1,4224 +1,4197 @@
-Gene_Symbol	type	file	classification
-A1CF	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-AAK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-AATK	Kinase	PfamKinase, OncoKBv20240704	NA
-ABCG2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ABI1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ABI2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ABL1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ABL2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ABRAXAS1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-AC008770.3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AC023509.3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AC092835.1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AC138696.1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ACHE	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ACK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ACKR3	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ACSL3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ACSL6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ACTG1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ACTR2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ACTR2B	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ACVR1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ACVR1B	Kinase, TumorSuppressorGene	PfamKinase, OncoKBv20240704	TumorSuppressorGene
-ACVR1C	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-ACVR2A	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-ACVR2B	Kinase	PfamKinase, OncoKBv20240704	NA
-ACVRL1	Kinase	PfamKinase, OncoKBv20240704	NA
-ACY1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ADAMTS18	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ADAMTS8	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ADAMTS9	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ADAMTS9-AS2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ADARB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ADCK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ADCK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ADCK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ADCK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ADCK5	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ADHFE1	Oncogene	OncoKBv20240704	Oncogene
-ADNP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ADNP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ADPRH	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AEBP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AEBP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AFAP1L2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AFDN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-AFF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-AFF3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-AFF4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-AGO1	Oncogene	OncoKBv20240704	Oncogene
-AGTR1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AHCTF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AHCYL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AHDC1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AHNAK	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AHR	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-AHRR	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-AIF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AIM2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AIMP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AIMP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AIP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AIRE	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AJAP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AJUBA	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-AKAP12	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AKAP8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AKAP8L	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AKAP9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-AKNA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AKR1B1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AKT1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-AKT2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-AKT3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ALDH18A1	Kinase	PfamKinase, OncoKBv20240704	NA
-ALDH1A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ALDH1L2	Oncogene	OncoKBv20240704	Oncogene
-ALDH2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ALK	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ALK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ALK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ALK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ALK7	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ALOX12B	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-ALOX15	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ALOX15B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ALPK1	Kinase	PfamKinase, OncoKBv20240704	NA
-ALPK2	Kinase	PfamKinase, OncoKBv20240704	NA
-ALPK3	Kinase	PfamKinase, OncoKBv20240704	NA
-ALPL	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ALX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ALX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ALX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-AMER1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-AMH	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AMHR2	Kinase	PfamKinase, OncoKBv20240704	NA
-AMPKa1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AMPKa2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ANAPC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ANGPTL4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ANHX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ANK1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ANKK1	Kinase	PfamKinase, OncoKBv20240704	NA
-ANKRD11	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ANKRD26	Oncogene	OncoKBv20240704	Oncogene
-ANKRD3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ANKZF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ANP32A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ANPa	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ANPb	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ANXA1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ANXA7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-APAF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-APC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-APITD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-APLNR	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-APOBEC3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-AR	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ARAF	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ARAFps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ARF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ARG1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ARGFX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ARHGAP26	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ARHGAP29	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ARHGAP35	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ARHGAP5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ARHGEF10	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ARHGEF10L	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ARHGEF12	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ARHGEF28	Oncogene	OncoKBv20240704	Oncogene
-ARID1A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ARID1B	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ARID2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ARID3A	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ARID3B	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-ARID3C	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ARID4A	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ARID4B	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ARID5A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ARID5B	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ARL11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ARL6IP5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ARMC10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ARMC5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ARNT	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ARNT2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ARNTL	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ARNTL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ARX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ASCL1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ASCL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ASCL3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ASCL4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ASCL5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ASH1L	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ASPSCR1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ASS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ASXL1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ASXL2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ATF1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ATF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATF3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ATF4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATF5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATF6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATF6B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATF7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATIC	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-ATM	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-ATMIN	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ATOH1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATOH7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATOH8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ATP1A1	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ATP2B3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ATP6V1B2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ATR	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-ATRIP	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ATRX	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ATXN2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ATXN7	Oncogene	OncoKBv20240704	Oncogene
-AURKA	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-AURKB	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-AURKC	Kinase	PfamKinase, OncoKBv20240704	NA
-AXIN1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-AXIN2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-AXL	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-AZGP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-AlphaK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AlphaK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AlphaK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AurA	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AurAps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AurAps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AurB	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AurBps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-AurC	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-B2M	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BAALC	Oncogene	OncoKBv20240704	Oncogene
-BACH1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BACH2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-BANP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BAP1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BARD1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BARHL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BARHL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BARK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BARK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BARX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BARX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BASP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BATF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BATF2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-BATF3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BAX	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BAZ1A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BAZ2A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BAZ2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BBC3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-BBX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BCKDK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BCL10	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BCL11A	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-BCL11B	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-BCL2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-BCL2L11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-BCL2L12	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BCL3	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-BCL6	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-BCL6B	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-BCL7A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BCL9	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-BCL9L	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BCLAF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BCOR	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BCORL1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BCR	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-BECN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BEX2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BHLHA15	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BHLHA9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BHLHE22	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BHLHE23	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BHLHE40	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BHLHE41	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-BICRA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BIK	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BIKE	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BIN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BIRC3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BIRC6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BLCAP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BLID	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BLK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-BLM	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BLNK	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BMAL1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-BMAL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BMF	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BMP10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BMP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BMP2K	Kinase	PfamKinase, OncoKBv20240704	NA
-BMP4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BMP5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BMPR1A	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-BMPR1Aps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BMPR1Aps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BMPR1B	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-BMPR2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-BMX	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-BNC1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BNC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BNIP3L	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BORCS8-MEF2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BPTF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BRAF	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-BRAFps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BRCA1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BRCA2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BRD2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BRD3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-BRD4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-BRD7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BRDT	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BRF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BRF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BRINP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BRIP1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BRK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-BRMS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BRMS1L	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BRSK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-BRSK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-BSX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-BTG1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-BTG2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-BTG3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BTG4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-BTK	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-BUB1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-BUB1B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-BUBR1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-C11orf95	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-C15orf65	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-C2orf40	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CABLES1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CACNA1D	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CACNA2D3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CAD	Oncogene	OncoKBv20240704	Oncogene
-CADM1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CADM2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CADM3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CADM4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CALR	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CAMK1	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMK1D	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMK1G	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMK2A	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMK2B	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMK2D	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMK2G	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMK2N1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CAMK4	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMKK1	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMKK2	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMKV	Kinase	PfamKinase, OncoKBv20240704	NA
-CAMTA1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-CAMTA2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CANT1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CAPG	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CARD11	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CARF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CARS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CARS1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CASC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CASC2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CASK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CASP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CASP3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CASP5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CASP8	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CASP9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CASZ1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CAT	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CAV1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CAVIN3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CBFA2T3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CBFB	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CBL	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CBLB	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CBLC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CBLL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CBX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CBX5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CC2D1A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CCAR1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCAR2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCDC136	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCDC154	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCDC169-SOHLH2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CCDC17	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CCDC6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CCDC67	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CCN2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCN3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCN6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCNB1IP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CCNB3	Oncogene	OncoKBv20240704	Oncogene
-CCNC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CCND1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CCND2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CCND3	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CCNDBP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CCNE1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CCNQ	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-CCR4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CCR7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CCRK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CD19	Oncogene	OncoKBv20240704	Oncogene
-CD209	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CD274	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CD276	Oncogene	OncoKBv20240704	Oncogene
-CD28	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CD4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CD44	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CD58	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-CD70	Oncogene	OncoKBv20240704	Oncogene
-CD74	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CD79A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CD79B	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CD82	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CDC2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDC42	Oncogene	OncoKBv20240704	Oncogene
-CDC42BPA	Kinase	PfamKinase, OncoKBv20240704	NA
-CDC42BPB	Kinase	PfamKinase, OncoKBv20240704	NA
-CDC42BPG	Kinase	PfamKinase, OncoKBv20240704	NA
-CDC5L	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CDC7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDC73	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CDCP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CDH1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CDH10	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CDH11	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CDH13	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CDH17	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CDH2	Oncogene	OncoKBv20240704	Oncogene
-CDH4	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-CDH5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CDK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK1	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK10	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDK11	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK11A	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK11B	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK12	CosmicCensus, Kinase, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-CDK13	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK14	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK15	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK16	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK17	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK18	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK19	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK19	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-CDK20	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK20	Kinase	PfamKinase, OncoKBv20240704	NA
-CDK2AP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CDK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDK4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-CDK4ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDK5ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK6	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-CDK7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDK7ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK8	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-CDK8ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CDK9	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDKL1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDKL2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDKL3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDKL4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDKL5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CDKN1A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CDKN1B	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CDKN1C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CDKN2A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CDKN2B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-CDKN2C	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CDO1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CDX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CDX2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-CDX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CEACAM1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CEBPA	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-CEBPB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CEBPD	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-CEBPE	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CEBPG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CEBPZ	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CENPA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CENPB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CENPBD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CENPBD1P	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CENPS	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CENPS	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CENPT	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CENPX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CEP43	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CEP89	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CFTR	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CGDps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CGGBP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CHAMP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CHCHD3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CHCHD7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CHD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CHD2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CHD4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CHD5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CHED	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CHEK1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-CHEK2	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-CHFR	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CHIC2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CHK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CHK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CHK2ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CHK2ps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CHKA	Kinase	PfamKinase, OncoKBv20240704	NA
-CHKB	Kinase	PfamKinase, OncoKBv20240704	NA
-CHST10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CHST11	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CHTF8	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-CHUK	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-CIC	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-CIITA	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CILK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CIT	Kinase	PfamKinase, OncoKBv20240704	NA
-CITED2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CIZ1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CK1a	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1a2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1aps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1aps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1aps3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1d	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1e	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1g1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1g2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1g2ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK1g3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK2a1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK2a1-rs	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CK2a2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CLDN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CLDN23	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CLIK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CLIK1L	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CLIP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CLK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CLK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CLK2ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CLK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CLK3ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CLK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CLOCK	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CLP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CLTC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CLTCL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CLU	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CMC4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CMTM3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CMTM5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CMTR2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-CNBD1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CNBP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CNDP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CNN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CNOT3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CNTNAP2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CNTRL	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-COL1A1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-COL2A1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-COL3A1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-COP1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-COPS2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-COQ8A	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-COQ8B	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-COT	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-COX6C	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CPEB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CPEB3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CPNE7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CPXCR1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CRBN	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-CREB1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-CREB3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CREB3L1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-CREB3L2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-CREB3L3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CREB3L4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CREB5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CREBBP	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CREBL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CREBZF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CREM	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-CRIK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CRK7	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CRKL	Oncogene	OncoKBv20240704	Oncogene
-CRLF2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CRNKL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CRNN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CRTC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CRTC3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CRX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CSF1R	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CSF1R	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-CSF2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CSF3R	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CSK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-CSMD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CSMD3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CSNK1A1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-CSNK1A1L	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK1D	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK1E	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK1G1	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK1G2	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK1G3	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK2A1	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK2A2	Kinase	PfamKinase, OncoKBv20240704	NA
-CSNK2A3	Kinase	PfamKinase, OncoKBv20240704	NA
-CSRNP1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-CSRNP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CSRNP3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CST5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CST6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CTCF	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-CTCFL	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-CTDSPL	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CTGF	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CTK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CTLA4	Oncogene	OncoKBv20240704	Oncogene
-CTNNA1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-CTNNA2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CTNNA3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CTNNB1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CTNNBIP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CTNND1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CTNND2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CTR9	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-CUL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CUL2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CUL3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CUL4A	Oncogene	OncoKBv20240704	Oncogene
-CUL5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CUX1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-CUX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CXCL10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CXCL12	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CXCL14	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CXCR2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CXCR4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CXXC1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-CXXC4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-CXXC5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-CYB561D2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CYB5A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CYB5R2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CYGB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-CYGD	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CYGF	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CYLD	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-CYP19A1	Oncogene	OncoKBv20240704	Oncogene
-CYP2C8	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-CYSLTR2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-CaMK1a	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK1b	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK1d	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK1g	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK2a	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK2b	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK2d	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK2g	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMKK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-CaMKK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ChaK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ChaK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-DAB2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DAB2IP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DACH1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-DACH2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DACT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DAPK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-DAPK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-DAPK3	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-DAXX	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-DBP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DBX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DBX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DCAF12L2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DCC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DCDC2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DCLK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DCLK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DCLK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DCLRE1A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DCN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DCTN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DCUN1D1	Oncogene	OncoKBv20240704	Oncogene
-DCUN1D3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DDB2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-DDIT3	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-DDR1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DDR2	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-DDX10	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DDX3X	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-DDX4	Oncogene	OncoKBv20240704	Oncogene
-DDX41	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-DDX5	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-DDX58	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DDX6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DEAF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DEFB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DEK	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-DENND2B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DENND2D	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DEUP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DFFA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DFNA5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DGCR8	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DGKA	Kinase	PfamKinase, OncoKBv20240704	NA
-DGKB	Kinase	PfamKinase, OncoKBv20240704	NA
-DGKG	Kinase	PfamKinase, OncoKBv20240704	NA
-DIABLO	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DICER1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-DIDO1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DIRAS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DIRAS3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DIS3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-DKK1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DKK3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DLC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DLEC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DLEU1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DLEU2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DLG1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DLK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-DLK1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DLX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DLX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DLX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DLX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DLX5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DLX6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMBT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DMBX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DMPK	Kinase	PfamKinase, OncoKBv20240704	NA
-DMPK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-DMPK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-DMRT1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMRT2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMRT3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMRTA1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMRTA2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMRTB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMRTC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DMTF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-DNAI7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DNAJA3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DNAJB1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DNAJB4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DNAJC11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DNAPK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-DND1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DNM2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-DNMT1	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	Oncogene
-DNMT3A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-DNMT3B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-DNTTIP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DOK1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DOK2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DOK3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DOT1L	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-DPF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DPF3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DPH1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DPP4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DPRX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DR1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DRAK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-DRAK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-DRAP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DRGX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DROSHA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DSC2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DSC3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DSP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DSTYK	Kinase	PfamKinase, OncoKBv20240704	NA
-DTX1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-DUSP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DUSP22	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-DUSP26	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DUSP4	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-DUSP5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DUSP6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DUSP9	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-DUX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DUX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DUX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DUX4L1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-DUX4L1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DUXA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-DYRK1A	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DYRK1B	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DYRK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DYRK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DYRK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-DZIP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-Dec-01	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-E2F1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-E2F2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-E2F3	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	Oncogene
-E2F4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-E2F5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-E2F6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-E2F7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-E2F8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-E4F1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EAF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EAF2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EBF1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-EBF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EBF3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-EBF4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ECRG4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ECSIT	Oncogene	OncoKBv20240704	Oncogene
-ECT2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ECT2L	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-EDA2R	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EDNRB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EEA1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EED	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-EEF1A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EEF1E1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EEF2K	Kinase	PfamKinase, OncoKBv20240704	NA
-EFNA5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EGFL7	Oncogene	OncoKBv20240704	Oncogene
-EGFR	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-EGLN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EGLN3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EGR1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-EGR2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-EGR3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EGR4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EHD3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EHF	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-EI24	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EIF1AX	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-EIF2AK1	Kinase	PfamKinase, OncoKBv20240704	NA
-EIF2AK2	Kinase	PfamKinase, OncoKBv20240704	NA
-EIF2AK3	Kinase	PfamKinase, OncoKBv20240704	NA
-EIF2AK4	Kinase	PfamKinase, OncoKBv20240704	NA
-EIF2B1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-EIF3E	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-EIF3F	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EIF4A2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-EIF4E	Oncogene	OncoKBv20240704	Oncogene
-ELF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ELF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ELF3	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ELF4	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ELF5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ELK1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ELK3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ELK4	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ELL	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-ELN	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-ELOA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EML4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-EMP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EMP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EMSY	Oncogene	OncoKBv20240704	Oncogene
-EMX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EMX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EN1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EN2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EOMES	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EP300	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-EP400	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-EPAS1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-EPB41	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EPB41L3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EPCAM	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-EPHA1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-EPHA10	Kinase	PfamKinase, OncoKBv20240704	NA
-EPHA2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-EPHA3	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-EPHA4	Kinase	PfamKinase, OncoKBv20240704	NA
-EPHA5	Kinase	PfamKinase, OncoKBv20240704	NA
-EPHA6	Kinase	PfamKinase, OncoKBv20240704	NA
-EPHA7	CosmicCensus, Kinase, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene, TumorSuppressorGene
-EPHA8	Kinase	PfamKinase, OncoKBv20240704	NA
-EPHB1	Kinase, Oncogene, TumorSuppressorGene	PfamKinase, OncoKBv20240704	Oncogene, TumorSuppressorGene
-EPHB2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-EPHB3	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-EPHB4	TumorSuppressorGene, Kinase, Oncogene	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	Oncogene
-EPHB6	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-EPOR	Oncogene	OncoKBv20240704	Oncogene
-EPS15	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ERBB2	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ERBB3	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ERBB4	TumorSuppressorGene, CosmicCensus, Kinase, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-ERC1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-ERCC1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ERCC2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ERCC3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ERCC4	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ERCC5	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ERF	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ERG	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ERN1	Kinase	PfamKinase, OncoKBv20240704	NA
-ERRFI1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-ESCO2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ESR1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ESR2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ESRP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ESRRA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ESRRB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ESRRG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ESX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ETAA1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-ETF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ETNK1	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-ETNK2	Kinase	PfamKinase, OncoKBv20240704	NA
-ETS1	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ETS2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ETV1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ETV2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ETV3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ETV3L	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ETV4	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ETV5	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-ETV6	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ETV7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EVX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EVX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-EWSR1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-EXT1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-EXT2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-EXTL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EXTL2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EXTL3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EYA4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-EZH1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-EZH2	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-EZHIP	Oncogene	OncoKBv20240704	Oncogene
-EZR	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-EphA1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA10	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA5	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA6	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA7	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphA8	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphB1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphB2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphB3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphB4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-EphB6	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ErbB2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ErbB3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ErbB4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk3ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk3ps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk3ps3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk3ps4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk5	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Erk7	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-FABP3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FADD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FAK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-FAM131B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FAM135B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FAM170A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FAM172A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FAM188A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FAM200B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FAM47C	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FANCA	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FANCC	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FANCD2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FANCE	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FANCF	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FANCG	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FANCL	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-FANCM	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-FAS	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FASTK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-FAT1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FAT3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FAT4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FBLN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FBLN2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FBP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FBXL13	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FBXL19	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FBXO11	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FBXO25	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FBXO31	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FBXO32	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FBXW7	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FCGR2B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FCRL4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FCSK	Kinase	PfamKinase, OncoKBv20240704	NA
-FEN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FER	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-FER1L4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FERD3L	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FERps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-FES	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-FEV	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-FEZF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FEZF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FGF1	Oncogene	OncoKBv20240704	Oncogene
-FGF10	Oncogene	OncoKBv20240704	Oncogene
-FGF14	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-FGF19	Oncogene	OncoKBv20240704	Oncogene
-FGF2	Oncogene	OncoKBv20240704	Oncogene
-FGF23	Oncogene	OncoKBv20240704	Oncogene
-FGF3	Oncogene	OncoKBv20240704	Oncogene
-FGF4	Oncogene	OncoKBv20240704	Oncogene
-FGF5	Oncogene	OncoKBv20240704	Oncogene
-FGF6	Oncogene	OncoKBv20240704	Oncogene
-FGF7	Oncogene	OncoKBv20240704	Oncogene
-FGF8	Oncogene	OncoKBv20240704	Oncogene
-FGF9	Oncogene	OncoKBv20240704	Oncogene
-FGFR1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-FGFR1OP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FGFR2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-FGFR3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-FGFR4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-FGR	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-FH	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FHIT	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FHL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FIGLA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FIP1L1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FIZ1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FKBP9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FLCN	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FLI1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-FLNA	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FLT1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-FLT1ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-FLT3	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-FLT4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-FLYWCH1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FMS	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-FNBP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FOLH1	Oncogene	OncoKBv20240704	Oncogene
-FOLR1	Oncogene	OncoKBv20240704	Oncogene
-FOS	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOSB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOSL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOSL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXA1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-FOXA2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-FOXA3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXB2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXC1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-FOXC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-FOXD4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD4L1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD4L3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD4L4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD4L5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXD4L6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXE1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXE3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXF1	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-FOXF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXG1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXH1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXI1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXI2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXI3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXJ1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXJ2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXJ3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXK1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXK2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXL2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-FOXM1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXN1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXN2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXN3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXN4	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-FOXO1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-FOXO3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-FOXO4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-FOXO6	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-FOXP1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-FOXP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXP3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-FOXP4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXQ1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FOXR1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-FOXR2	TranscriptionFactor	addTF_JL.tsv, AddedallOnco_Feb2017.tsv, OncoKBv20240704	NA
-FOXS1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-FPGT-TNNI3K	Kinase	PfamKinase, OncoKBv20240704	NA
-FRAP	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-FRK	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-FRS2	Oncogene	OncoKBv20240704	Oncogene
-FRS3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FSTL1	Oncogene	OncoKBv20240704	Oncogene
-FSTL3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-FUBP1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-FURIN	Oncogene	OncoKBv20240704	Oncogene
-FUS	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-FXN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-FYN	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-FZR1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene, TumorSuppressorGene
-Fused	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-G0S2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-G11	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GAB1	Oncogene	OncoKBv20240704	Oncogene
-GAB2	Oncogene	OncoKBv20240704	Oncogene
-GABARAP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GABPA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GABRA6	Oncogene	OncoKBv20240704	Oncogene
-GADD45A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GADD45B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GADD45G	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GADD45GIP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GAK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-GALK1	Kinase	PfamKinase, OncoKBv20240704	NA
-GALK2	Kinase	PfamKinase, OncoKBv20240704	NA
-GALR1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GANAB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GAS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GAS5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GAS7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-GATA1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-GATA2	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-GATA3	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-GATA4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-GATA5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-GATA6	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-GATAD2A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GATAD2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GBP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GBX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GBX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GCK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-GCM1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GCM2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GCN2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GFI1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GFI1B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GGNBP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GJA1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GJB2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GKN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GKN2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GLI1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-GLI2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GLI3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GLI4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GLIPR1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GLIS1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GLIS2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GLIS3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GLMP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GLS2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GLTSCR1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GLTSCR2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GLYR1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GMEB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GMEB2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GMPS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-GNA11	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-GNA12	Oncogene	OncoKBv20240704	Oncogene
-GNA13	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-GNAQ	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-GNAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-GNAT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GNB1	Oncogene	OncoKBv20240704	Oncogene
-GNB2L1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GNMT	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GOLGA5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-GOPC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-GORAB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GPBP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GPBP1L1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GPC3	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-GPC5	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-GPHN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-GPRC5A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GPRK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GPRK5	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GPRK6	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GPRK6ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GPRK7	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GPS2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-GPX3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GRB7	Oncogene	OncoKBv20240704	Oncogene
-GREM1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-GRHL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GRHL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GRHL3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GRIN2A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-GRK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GRK1	Kinase	PfamKinase, OncoKBv20240704	NA
-GRK2	Kinase	PfamKinase, OncoKBv20240704	NA
-GRK3	Kinase	PfamKinase, OncoKBv20240704	NA
-GRK4	Kinase	PfamKinase, OncoKBv20240704	NA
-GRK5	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GRK5	Kinase	PfamKinase, OncoKBv20240704	NA
-GRK6	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GRK6	Kinase	PfamKinase, OncoKBv20240704	NA
-GRK7	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-GRK7	Kinase	PfamKinase, OncoKBv20240704	NA
-GRM3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-GSC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GSC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GSDME	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GSK3A	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-GSK3B	Kinase, TumorSuppressorGene, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	Oncogene
-GSN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GSTP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GSTT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GSX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GSX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GTF2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GTF2I	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-GTF2IRD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GTF2IRD2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GTF2IRD2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GTF3A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-GTPBP4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-GUCY2C	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-GUCY2D	Kinase	PfamKinase, OncoKBv20240704	NA
-GUCY2F	Kinase	PfamKinase, OncoKBv20240704	NA
-GZF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-H1-3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-H1-4	Oncogene	OncoKBv20240704	Oncogene
-H1-5	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-H11	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-H19	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-H2AC17	Oncogene	OncoKBv20240704	Oncogene
-H2AFX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-H2AX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-H3-3A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-H3-3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-H3C2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-H3F3A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-H3F3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-H4C9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HACD4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HACE1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HAND1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HAND2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HBP1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-HCAR2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HCK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-HDAC1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-HDAC2	Oncogene	OncoKBv20240704	Oncogene
-HDAC3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HDAC4	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-HDAC7	Oncogene	OncoKBv20240704	Oncogene
-HDX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HECA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HELT	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HEPACAM	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HERPUD1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HES1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HES2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HES3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HES4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HES5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HES6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HES7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HESX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HEY1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HEY2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HEYL	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HFE	Oncogene	OncoKBv20240704	Oncogene
-HGF	Oncogene	OncoKBv20240704	Oncogene
-HGK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-HH498	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-HHEX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HIC1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-HIC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HIF1A	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-HIF3A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HINFP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HINT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HIP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HIPK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-HIPK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-HIPK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-HIPK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-HIRA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-HIST1H3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HIST1H4I	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HIVEP1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-HIVEP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HIVEP3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-HK1	Kinase	PfamKinase, OncoKBv20240704	NA
-HK2	Kinase	PfamKinase, OncoKBv20240704	NA
-HK3	Kinase	PfamKinase, OncoKBv20240704	NA
-HKDC1	Kinase	PfamKinase, OncoKBv20240704	NA
-HKR1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HLA-A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-HLA-B	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-HLA-C	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-HLF	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HLTF	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HLX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HMBOX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HMG20A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HMG20B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HMGA1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-HMGA2	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-HMGN2P46	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HMGN3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HMX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HMX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HMX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HNF1A	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-HNF1B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HNF4A	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-HNF4G	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HNRNPA2B1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HOMER2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HOMEZ	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOOK3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HOPX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HOTS	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HOXA1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA11	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-HOXA13	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HOXA2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXA9	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HOXB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB13	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-HOXB2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXB9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXC10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXC11	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HOXC12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXC13	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HOXC4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXC5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXC6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXC8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXC9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXD10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXD11	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HOXD12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXD13	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-HOXD3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXD4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXD8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HOXD9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HPGD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HPK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-HRAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-HRASLS2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HRG	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HRI	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-HRIps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-HSD17B2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-HSD3B1	Oncogene	OncoKBv20240704	Oncogene
-HSER	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-HSF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSF4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSF5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSFX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSFX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSFY1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSFY2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-HSP90AA1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-HSP90AB1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-HSP90B1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HSPB7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HSPD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HTATIP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-HTRA1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HTRA2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HTRA3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-HUNK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-Haspin	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ICK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-ICOSLG	Oncogene	OncoKBv20240704	Oncogene
-ID1	Oncogene	OncoKBv20240704	Oncogene
-ID3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ID4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IDH1	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-IDH2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-IER3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IFI16	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IFNGR1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-IFT88	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGF1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-IGF1R	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-IGF2	Oncogene	OncoKBv20240704	Oncogene
-IGF2BP2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-IGF2R	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGFALS	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGFBP3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGFBP4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGFBP5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGFBP7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGFBPL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IGH	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-IGH	Oncogene	addedToallOnco_Feb2017.tsv, OncoKBv20240704	NA
-IGH-@	Oncogene	addedToallOnco_Feb2017.tsv, OncoKBv20240704	NA
-IGH@	Oncogene	addedToallOnco_Feb2017.tsv, OncoKBv20240704	NA
-IGK	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-IGL	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-IGL	Oncogene	addedToallOnco_Feb2017.tsv, OncoKBv20240704	NA
-IGL-@	Oncogene	addedToallOnco_Feb2017.tsv, OncoKBv20240704	NA
-IGL@	Oncogene	addedToallOnco_Feb2017.tsv, OncoKBv20240704	NA
-IKBKB	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-IKBKE	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-IKKa	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-IKKb	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-IKKe	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-IKZF1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-IKZF2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-IKZF3	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-IKZF4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IKZF5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IL17A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IL17RD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IL2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-IL21R	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-IL24	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IL3	Oncogene	OncoKBv20240704	Oncogene
-IL6ST	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-IL7R	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-ILK	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-ING1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-ING2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ING3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ING4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ING5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-INGX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-INHA	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-INHBA	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-INPP4B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-INPPL1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-INSM1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-INSM2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-INSR	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-INSRR	Kinase	PfamKinase, OncoKBv20240704	NA
-INTS6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-IQGAP1	Oncogene	OncoKBv20240704	Oncogene
-IQGAP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IRAG1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IRAG2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-IRAK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-IRAK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-IRAK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-IRAK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-IRE1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-IRE2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-IRF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-IRF2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-IRF3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-IRF4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-IRF5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-IRF6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IRF7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IRF8	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-IRF9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IRR	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-IRS1	Oncogene	OncoKBv20240704	Oncogene
-IRS2	Oncogene	OncoKBv20240704	Oncogene
-IRS4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-IRX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-IRX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IRX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IRX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IRX5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-IRX6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ISG15	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ISL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ISL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ISX	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ITGA5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ITGA7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ITGAV	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ITGB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ITGB3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ITK	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-ITPKB	Oncogene	OncoKBv20240704	Oncogene
-JAK1	Kinase, CosmicCensus, Oncogene, TumorSuppressorGene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene, TumorSuppressorGene
-JAK2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-JAK3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-JARID2	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-JAZF1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-JDP2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-JNK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-JNK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-JNK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-JRK	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-JRKL	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-JUN	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-JUNB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-JUND	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-JUP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KALRN	Kinase	PfamKinase, OncoKBv20240704	NA
-KANK1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KAT5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KAT6A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KAT6B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KAT7	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-KCMF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KCNIP3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KCNJ5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KCNRG	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KDM2A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KDM2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KDM3A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KDM3B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KDM5A	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-KDM5B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KDM5C	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-KDM5D	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-KDM6A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-KDM8	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KDR	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-KDSR	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KEAP1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-KEL	Oncogene	OncoKBv20240704	Oncogene
-KHS1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-KHS2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-KIAA1549	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KIF1B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KIF5B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KIF7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KIN	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KIS	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-KISS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KIT	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-KL	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KLF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF10	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-KLF11	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF13	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF14	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF15	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF16	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF17	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-KLF3	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-KLF4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-KLF5	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	Oncogene
-KLF6	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-KLF7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLF9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-KLHL6	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-KLK10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KLK2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KLK6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KMT2A	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-KMT2B	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-KMT2C	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-KMT2D	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-KNL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KNSTRN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-KRAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-KRIT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KRT19	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-KSGCps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-KSR1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-KSR2	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-KTN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-L3MBTL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-L3MBTL3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-L3MBTL4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-LARP4B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LASP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LAT2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LATS1	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-LATS2	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-LBX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LBX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LCK	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-LCOR	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LCORL	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LCP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LEF1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-LEFTY1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LEFTY2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LEPROTL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LEUTX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LGALS7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LGR5	Oncogene	OncoKBv20240704	Oncogene
-LHFPL6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LHX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LHX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LHX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LHX4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-LHX5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LHX6	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-LHX8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LHX9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LIFR	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LIMA1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LIMD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LIMK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-LIMK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-LIMK2ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-LIN28A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LIN28B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LIN54	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LIN9	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LINC-PINT	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LITAF	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LKB1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-LLGL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LMNA	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-LMNTD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LMO1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-LMO2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-LMR1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-LMR2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-LMR3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-LMTK2	Kinase	PfamKinase, OncoKBv20240704	NA
-LMTK3	Kinase	PfamKinase, OncoKBv20240704	NA
-LMX1A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LMX1B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-LOC401317	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LOK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-LOX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LPP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LRIG1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LRIG3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LRMP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LRP1B	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-LRP5	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-LRP6	Oncogene	OncoKBv20240704	Oncogene
-LRRC3B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LRRC4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LRRK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-LRRK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-LSAMP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LSM14A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-LTB	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-LTF	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-LTK	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-LXN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-LYL1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-LYN	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-LZK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-LZTR1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-LZTS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MACC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MAD1L1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MAD2L2	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-MADD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MAF	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-MAFA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MAFB	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-MAFF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MAFG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MAFK	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MAK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAL	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MAL2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-MALAT1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MALT1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MAML2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MAP2K1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-MAP2K1ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MAP2K2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-MAP2K2ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MAP2K3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP2K4	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-MAP2K5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP2K6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP2K7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP3K1	Kinase, CosmicCensus, TumorSuppressorGene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-MAP3K10	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MAP3K10	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP3K11	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MAP3K11	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP3K12	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP3K13	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-MAP3K14	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-MAP3K15	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP3K19	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP3K2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP3K20	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP3K21	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-MAP3K3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP3K4	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-MAP3K5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP3K6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAP3K7	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-MAP3K7	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704	Oncogene
-MAP3K8	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-MAP3K8	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MAP3K9	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MAP3K9	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP4K1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-MAP4K2	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP4K3	Kinase	PfamKinase, OncoKBv20240704	NA
-MAP4K4	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-MAP4K5	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-MAPK10	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-MAPK11	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK12	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK13	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK14	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK15	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK3	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-MAPK4	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK6	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK7	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK8	Kinase	PfamKinase, OncoKBv20240704	NA
-MAPK9	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-MAPKAPK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAPKAPK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAPKAPK5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAPKAPKps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARCKS	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MARK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MARK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MARK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MARK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MARKps01	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps02	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps03	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps04	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps05	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps07	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps08	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps09	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps10	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps11	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps12	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps13	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps15	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps16	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps17	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps18	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps19	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps20	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps21	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps22	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps23	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps24	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps25	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps26	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps27	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps28	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps29	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARKps30	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MARVELD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MAST1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAST2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAST3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAST4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MASTL	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MAT2A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MATK	Kinase	PfamKinase, OncoKBv20240704	NA
-MAX	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-MAZ	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MB21D2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MBD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MBD2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MBD3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MBD4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-MBD6	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-MBNL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MCC	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MCL1	Oncogene	OncoKBv20240704	Oncogene
-MCM9	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MCPH1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MDC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MDM2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MDM4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MDS2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MECOM	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-MECP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MED12	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-MEF2A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MEF2B	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-MEF2C	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-MEF2D	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-MEG3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MEIS1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MEIS2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MEIS3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MEIS3P1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MELK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MEN1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-MEOX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MEOX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MER	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MERTK	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-MESP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MESP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MET	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-MFSD2A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MGA	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-MGAM	Oncogene	OncoKBv20240704	Oncogene
-MGMT	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MIA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIA2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIDEAS	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-MINDY3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MINK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MINK1	Kinase	PfamKinase, OncoKBv20240704	NA
-MIR1-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR1-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR100	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR101-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR101-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR106A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR107	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR10A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR122	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR1226	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR124-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR124-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR124-3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR1247	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR125A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR125B1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR125B2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR126	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR127	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR129-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR129-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR1291	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR1297	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR130A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR132	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR133A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR133A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR134	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR135A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR135A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR136	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR137	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR138-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR138-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR140	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR141	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR142	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR143	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR145	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR146A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR147A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR148A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR148B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR149	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR150	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR152	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR155	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR15A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR16-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR16-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR17	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR181A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR181A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR181B1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR181B2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR181C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR182	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR183	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR185	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR186	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR187	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR18A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR18B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR192	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR193A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR193B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR194-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR194-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR195	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR196A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR196B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR198	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR199A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR200A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR200B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR200C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR203A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR204	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR205	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR206	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR20A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR210	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR211	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR214	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR215	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR217	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR218-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR218-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR219A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR22	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR222	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR223	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR23A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR23B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR24-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR25	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR26A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR26A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR26B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR27A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR27B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR28	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR296	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR29A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR29B1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR29C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR302B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR30A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR30C1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR31	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR320A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR326	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR329-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR335	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR338	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR33A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR340	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR34A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR34B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR34C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR367	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR370	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR375	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR378A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR383	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR409	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR410	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR422A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR424	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR449A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR449B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR451A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR483	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR486-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR487B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR490	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR493	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR494	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR495	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR497	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR502	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR503	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR504	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR505	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR508	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR509-3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR511	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR517A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR519D	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR520B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR520C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR551A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR574	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR615	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR636	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR7-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR7-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR7-3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR708	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR874	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR888	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR9-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR9-2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR9-3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR941-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR98	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIR99A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7A3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7D	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7E	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7F1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7F2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7G	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MIRLET7I	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MISR2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MITF	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-MIXL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MKI67	Oncogene	OncoKBv20240704	Oncogene
-MKNK1	Kinase	PfamKinase, OncoKBv20240704	NA
-MKNK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MKNK2	Kinase	PfamKinase, OncoKBv20240704	NA
-MKX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MLF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MLH1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-MLH3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-MLK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MLK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MLK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MLK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MLKL	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MLLT1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MLLT10	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MLLT11	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MLLT3	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MLLT6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MLX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MLXIP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MLXIPL	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MME	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MN1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MNK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MNK1ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MNK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MNT	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-MNX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-MOB1A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MOB1B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MOB3B	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-MOK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MOS	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MPL	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MPSK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MPSK1ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MRCKa	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MRCKb	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MRCKps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MRE11	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-MRTFA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MRVI1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MSANTD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MSANTD3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MSANTD4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MSC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MSGN1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MSH2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-MSH3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-MSH6	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-MSI1	Oncogene	OncoKBv20240704	Oncogene
-MSI2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MSK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MSK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MSMB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MSN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MSSK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MST1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-MST1R	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704	Oncogene
-MST1R	TumorSuppressorGene, Kinase, Oncogene	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	Oncogene
-MST2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MST3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MST3ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MST4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-MSX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MSX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MT1DP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MT1F	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MT1G	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MT1M	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MT2A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MTAP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-MTCP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MTERF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MTERF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MTERF3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MTERF4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MTF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MTF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MTHFD2	Oncogene	OncoKBv20240704	Oncogene
-MTOR	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704	Oncogene
-MTOR	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-MTSS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MTUS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MUC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MUC16	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MUC4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MUS81	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MUSK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MUTYH	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-MVD	Kinase	PfamKinase, OncoKBv20240704	NA
-MVK	Kinase	PfamKinase, OncoKBv20240704	NA
-MXD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MXD3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MXD4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MXI1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-MYB	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-MYBBP1A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MYBL1	TranscriptionFactor, Oncogene	addTF_JL.tsv, AddedallOnco_Feb2017.tsv, OncoKBv20240704	Oncogene
-MYBL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYC	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-MYCL	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-MYCN	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-MYD88	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MYF5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYF6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYH11	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-MYH9	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-MYLK	Kinase	PfamKinase, OncoKBv20240704	NA
-MYLK2	Kinase	PfamKinase, OncoKBv20240704	NA
-MYLK3	Kinase	PfamKinase, OncoKBv20240704	NA
-MYLK4	Kinase	PfamKinase, OncoKBv20240704	NA
-MYNN	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYO18B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MYO1A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MYO3A	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MYO3B	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-MYO5A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-MYOD1	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-MYOG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYPOP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYRF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYRFL	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYSM1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MYT1	Kinase, TranscriptionFactor	Kincat_Hsap.08.02.txt, addTF_JL.tsv, OncoKBv20240704	NA
-MYT1L	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-MZB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-MZF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-N4BP2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NAB2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NACA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NACC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NADK	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-NADK2	Kinase	PfamKinase, OncoKBv20240704	NA
-NAIF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NANOG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NANOGNB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NANOGP8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NAPEPLD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NAXD	Kinase	PfamKinase, OncoKBv20240704	NA
-NBEA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NBN	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-NCKIPSD	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NCOA1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-NCOA2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-NCOA3	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-NCOA4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NCOA5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NCOR1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-NCOR2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NCSTN	Oncogene	OncoKBv20240704	Oncogene
-NDN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NDR1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NDR2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NDRG1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NDRG2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NDRG4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NDST4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NEDD4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NEDD4L	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NEK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK10	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK11	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK2ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NEK2ps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NEK2ps3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NEK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK4ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NEK5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK8	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEK9	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NEURL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NEUROD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NEUROD2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NEUROD4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NEUROD6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NEUROG1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NEUROG2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NEUROG3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NF1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-NF2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-NFAT5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFATC1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFATC2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-NFATC3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFATC4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFE2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-NFE2L1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFE2L2	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-NFE2L3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFE4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFIA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFIB	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-NFIC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFIL3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFIX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFKB1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-NFKB2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-NFKBIA	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-NFKBIE	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NFX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFXL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFYA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFYB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NFYC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NGFR	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NHERF1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene, TumorSuppressorGene
-NHLH1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NHLH2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NIK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NIM1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NIM1K	Kinase	PfamKinase, OncoKBv20240704	NA
-NIN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NINJ1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NIT2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NKRF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX1-1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX1-2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX2-1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-NKX2-2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX2-3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX2-4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX2-5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX2-6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX2-8	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-NKX3-1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-NKX3-2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX6-1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX6-2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NKX6-3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NLK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NME1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NME2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NNAT	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NOBOX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NOL7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NONO	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NOP53	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NOTCH1	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-NOTCH2	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-NOTCH3	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene, TumorSuppressorGene
-NOTCH4	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-NOTO	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NOV	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NPAS1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NPAS2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-NPAS3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NPAS4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NPM1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-NPR1	Kinase	PfamKinase, OncoKBv20240704	NA
-NPR2	Kinase	PfamKinase, OncoKBv20240704	NA
-NPRL2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NQO1	Oncogene	OncoKBv20240704	Oncogene
-NR0B1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR0B2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NR1D1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR1D2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR1H2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR1H3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR1H4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR1I2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-NR1I3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR2C1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR2C2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-NR2E1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR2E3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR2F1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR2F2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR2F6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR3C1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR3C2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR4A1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-NR4A2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR4A3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-NR5A1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR5A2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NR6A1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NRAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-NRBP1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-NRBP2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NRCAM	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NRF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-NRG1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-NRK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-NRL	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-NRSN2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NSD1	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-NSD2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-NSD3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NSD3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NT5C2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-NTHL1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-NTRK1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-NTRK2	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-NTRK3	TumorSuppressorGene, CosmicCensus, Kinase, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-NUAK1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-NUAK2	Kinase	PfamKinase, OncoKBv20240704	NA
-NUF2	Oncogene	OncoKBv20240704	Oncogene
-NUMA1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NUMB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NUP214	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-NUP98	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-NUPR1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-NUTM1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NUTM2B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NUTM2D	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-NuaK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-NuaK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-OBSCN	Kinase	PfamKinase, OncoKBv20240704	NA
-OLFM4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-OLIG1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OLIG2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-OLIG3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OMD	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ONECUT1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ONECUT2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-ONECUT3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OPCML	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-OSCP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-OSGIN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-OSR1	Kinase, TranscriptionFactor	Kincat_Hsap.08.02.txt, addTF_JL.tsv, OncoKBv20240704	NA
-OSR2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OTP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OTX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OTX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OVOL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OVOL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OVOL3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-OXSR1	Kinase, TranscriptionFactor	Kincat_Hsap.08.02.txt, addTF_JL.tsv, OncoKBv20240704	NA
-OXSR1	Kinase	PfamKinase, OncoKBv20240704	NA
-Obscn	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-P2RY8	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PA2G4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PABPC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PACRG	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PAEP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PAFAH1B1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PAFAH1B2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PAIP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PAK1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-PAK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PAK2ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PAK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PAK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PAK5	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-PAK6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PALB2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PANO1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PANX2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PAPSS1	Kinase	PfamKinase, OncoKBv20240704	NA
-PAPSS2	Kinase	PfamKinase, OncoKBv20240704	NA
-PARK2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PARK7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PARP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-PASK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PATZ1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-PAWR	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PAX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PAX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PAX3	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-PAX4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PAX5	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-PAX6	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PAX7	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-PAX8	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-PAX9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PBK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PBRM1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PBX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-PBX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PBX2P1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PBX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PBX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PCBP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PCDH10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PCDH17	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PCDH8	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PCDH9	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PCDHGC3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PCGF2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PCGF6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PCM1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PCTAIRE1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PCTAIRE2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PCTAIRE3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PDCD1	Oncogene	OncoKBv20240704	Oncogene
-PDCD1LG2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-PDCD4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PDCD5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PDE4DIP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PDGFB	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-PDGFRA	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-PDGFRB	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-PDGFRL	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PDGFRa	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PDGFRb	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PDHK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PDHK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PDHK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PDHK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PDIK1L	Kinase	PfamKinase, OncoKBv20240704	NA
-PDK1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704	Oncogene
-PDLIM4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PDPK1	Kinase	PfamKinase, OncoKBv20240704	NA
-PDS5B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-PDSS2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PDX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PEA15	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PEAK1	Kinase	PfamKinase, OncoKBv20240704	NA
-PEBP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PEG3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PEK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PER1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PER2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PF4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PFN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PFTAIRE1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PFTAIRE2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PGBD5	Oncogene	OncoKBv20240704	Oncogene
-PGR	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	Oncogene
-PGRMC2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHACTR4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHC3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PHF19	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-PHF20	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PHF21A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PHF6	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PHIP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHKG1	Kinase	PfamKinase, OncoKBv20240704	NA
-PHKG2	Kinase	PfamKinase, OncoKBv20240704	NA
-PHKg1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PHKg1ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PHKg1ps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PHKg1ps3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PHKg2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PHLDA2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHLDA3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PHLPP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-PHLPP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-PHOX2A	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PHOX2B	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-PI4K2B	Kinase	PfamKinase, OncoKBv20240704	NA
-PI4KA	Kinase	PfamKinase, OncoKBv20240704	NA
-PI4KB	Kinase	PfamKinase, OncoKBv20240704	NA
-PIAS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PICALM	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PIERCE2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PIGA	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PIK3C2A	Kinase	PfamKinase, OncoKBv20240704	NA
-PIK3C2B	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-PIK3C2G	Kinase	PfamKinase, OncoKBv20240704	NA
-PIK3C3	Kinase	PfamKinase, OncoKBv20240704	NA
-PIK3CA	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-PIK3CB	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-PIK3CD	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-PIK3CG	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-PIK3R1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PIK3R2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PIK3R3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PIK3R4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PIM1	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-PIM2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PIM3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PIN1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PINK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PINX1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PITSLRE	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PITX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PITX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PITX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PIWIL2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PKACa	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKACb	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKACg	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCa	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCb	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCd	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCe	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCg	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCh	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCi	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCips	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCt	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKCz	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKD1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, OncoKBv20240704	NA
-PKD2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKD3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKG1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKG2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PKMYT1	Kinase	PfamKinase, OncoKBv20240704	NA
-PKN1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PKN2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PKN3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PKNOX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PKNOX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PKR	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PLA2G16	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLA2G2A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLA2G7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLA2R1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLAAT2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLAAT3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLAAT4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLAG1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-PLAGL1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PLAGL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PLCB3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLCD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLCE1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLCG1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-PLCG2	Oncogene	OncoKBv20240704	Oncogene
-PLD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLEKHO1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-PLK1ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PLK1ps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PLK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-PLK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PLK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PLK5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PLSCR1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PLXNC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PMAIP1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PML	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PMS1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PMS2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PMVK	Kinase	PfamKinase, OncoKBv20240704	NA
-PNCK	Kinase	PfamKinase, OncoKBv20240704	NA
-PNN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-POGK	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POLD1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-POLE	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-POLG	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-POLQ	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-POMK	Kinase	PfamKinase, OncoKBv20240704	NA
-POT1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-POU1F1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU2AF1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-POU2F1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU2F2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-POU2F3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-POU3F1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU3F2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-POU3F3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU3F4	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-POU4F1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU4F2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU4F3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU5F1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-POU5F1B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU5F2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU6F1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-POU6F2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PPARA	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PPARD	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PPARG	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-PPFIBP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PPM1A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPM1D	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-PPM1L	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP1CA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP1R1B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP2CA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP2CB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP2R1A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PPP2R1B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP2R2A	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PPP2R2C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP2R4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP2R5C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP3CC	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PPP6C	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PRAG1	Kinase	PfamKinase, OncoKBv20240704	NA
-PRCC	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-PRDM1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-PRDM10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRDM11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PRDM12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRDM13	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRDM14	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRDM15	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRDM16	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-PRDM2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-PRDM4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PRDM5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PRDM6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRDM8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRDM9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PREB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PREX2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PRF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PRICKLE1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PRKAA1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-PRKAA2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-PRKACA	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-PRKACB	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKACG	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKAR1A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PRKCA	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKCB	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-PRKCD	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-PRKCDBP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PRKCE	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-PRKCG	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKCH	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKCI	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-PRKCQ	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKCSH	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PRKCZ	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKD1	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKD2	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKD3	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKDC	Kinase, Oncogene, TumorSuppressorGene	PfamKinase, OncoKBv20240704	Oncogene, TumorSuppressorGene
-PRKG1	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKG2	Kinase	PfamKinase, OncoKBv20240704	NA
-PRKN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-PRKX	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PRKXps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PRKY	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PRMT3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRODH	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PROP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PROX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-PROX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRP4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PRP4ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PRPF40B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PRPF4B	Kinase	PfamKinase, OncoKBv20240704	NA
-PRPF8	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PRPK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PRR12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PRR5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PRRX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-PRRX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PSIP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PSKH1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PSKH1ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-PSKH2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-PSMB2	Oncogene	OncoKBv20240704	Oncogene
-PTCH1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PTCH2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTCSC3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTEN	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PTENP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTF1A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PTGDR	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTK2	Kinase	PfamKinase, OncoKBv20240704	NA
-PTK2B	Kinase	PfamKinase, OncoKBv20240704	NA
-PTK6	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-PTK7	Kinase	PfamKinase, OncoKBv20240704	NA
-PTPA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTPN1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene, TumorSuppressorGene
-PTPN11	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-PTPN12	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTPN13	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PTPN14	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PTPN2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-PTPN23	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTPN6	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PTPRB	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PTPRC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PTPRD	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PTPRJ	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PTPRK	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PTPRS	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-PTPRT	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-PURA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PURB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PURG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-PWAR4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PWWP2A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-PYCARD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PYHIN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-PYK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-QIK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-QKI	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-QSK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RAB25	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RAB35	Oncogene	OncoKBv20240704	Oncogene
-RAB7A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RABEP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RAC1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-RAC2	Oncogene	OncoKBv20240704	Oncogene
-RACK1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RAD17	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-RAD21	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-RAD23B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RAD50	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RAD51	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RAD51B	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-RAD51C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-RAD51D	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RAF1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-RAF1ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RAG1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RALGDS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RANBP2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-RANBP9	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RAP1A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RAP1GAP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RAP1GDS1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RARA	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-RARB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-RARG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RARRES3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASA1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RASAL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASAL2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASL10A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASL10B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASL11A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASSF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASSF10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASSF2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASSF3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASSF4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASSF5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RASSF8	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RAX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RAX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RB1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-RB1CC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBAK	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RBBP7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBBP8	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBCK1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RBL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBL2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBM10	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-RBM14	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBM15	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-RBM38	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBM4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBM5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBM6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBMS3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBMX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RBPJ	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RBPJL	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RBSN	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RCHY1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RECK	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RECQL	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RECQL4	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-REL	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-RELA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RELB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-REPIN1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-REST	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-RET	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-REV3L	Oncogene	OncoKBv20240704	Oncogene
-REXO4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFK	Kinase	PfamKinase, OncoKBv20240704	NA
-RFWD2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RFWD3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RFX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFX5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFX6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFX7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RFX8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RGPD3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RGS7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RHEB	Oncogene	OncoKBv20240704	Oncogene
-RHOA	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-RHOB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RHOBTB2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RHOH	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RHOK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RHOXF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RHOXF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RHOXF2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RICTOR	Oncogene	OncoKBv20240704	Oncogene
-RIGI	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RINT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RIOK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RIOK2	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704	Oncogene
-RIOK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RIOK3ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RIPK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-RIPK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-RIPK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-RIPK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RIPK4	Kinase	PfamKinase, OncoKBv20240704	NA
-RIT1	Oncogene	OncoKBv20240704	Oncogene
-RITA1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RLF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RMI2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RNASEH2A	Oncogene	OncoKBv20240704	Oncogene
-RNASEH2B	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RNASEL	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-RNASET2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RNAseL	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RND3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RNF111	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RNF144A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RNF180	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RNF213	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RNF43	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-RNF8	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RNH1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ROBO1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-ROBO2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ROCK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-ROCK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-RON	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ROR1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-ROR2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-RORA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RORB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RORC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ROS	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ROS1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-RPA1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RPL10	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RPL11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RPL22	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RPL5	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-RPN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RPRM	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RPS15	Oncogene	OncoKBv20240704	Oncogene
-RPS6KA1	Kinase	PfamKinase, OncoKBv20240704	NA
-RPS6KA2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-RPS6KA3	Kinase	PfamKinase, OncoKBv20240704	NA
-RPS6KA4	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-RPS6KA5	Kinase	PfamKinase, OncoKBv20240704	NA
-RPS6KA6	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-RPS6KB1	Kinase	PfamKinase, OncoKBv20240704	NA
-RPS6KB2	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-RPS6KC1	Kinase	PfamKinase, OncoKBv20240704	NA
-RPS6KL1	Kinase	PfamKinase, OncoKBv20240704	NA
-RPTOR	Oncogene	OncoKBv20240704	Oncogene
-RRAGC	Oncogene	OncoKBv20240704	Oncogene
-RRAS	Oncogene	OncoKBv20240704	Oncogene
-RRAS2	Oncogene	OncoKBv20240704	Oncogene
-RREB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RSK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RSK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RSK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RSK4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RSKL1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RSKL2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-RSKR	Kinase	PfamKinase, OncoKBv20240704	NA
-RSPO2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RSPO3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-RTEL1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RTN4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RTN4IP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-RUNX1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-RUNX1T1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-RUNX2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-RUNX3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-RXRA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RXRB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RXRG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-RYBP	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-RYK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-RYKps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-S100A11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-S100A2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-S100A7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SAA1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SAFB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SAFB2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SAKps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SALL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SALL2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SALL3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SALL4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-SAMD9L	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SAMHD1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SASH1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SATB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SATB2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SBDS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SBK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SBK1	Kinase	PfamKinase, OncoKBv20240704	NA
-SBK2	Kinase	PfamKinase, OncoKBv20240704	NA
-SBK3	Kinase	PfamKinase, OncoKBv20240704	NA
-SCAND3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SCG5	Oncogene	OncoKBv20240704	Oncogene
-SCGB3A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SCMH1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SCML4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SCRIB	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SCRT1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SCRT2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SCUBE2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SCX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SCYL1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-SCYL2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SCYL2ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SCYL3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SDC4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SDHA	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SDHAF2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SDHB	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SDHC	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SDHD	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SEBOX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SEC14L2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SELENBP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SEMA3B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SEMA3F	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SEPT4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SEPT5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SEPT6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SEPT9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SEPTIN4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SEPTIN5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SEPTIN6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SEPTIN9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SERPINB3	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-SERPINB5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SERPINI2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SESN1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SESN2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SESN3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SET	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-SETBP1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-SETD1A	Oncogene	OncoKBv20240704	Oncogene
-SETD1B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SETD2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SETDB1	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-SETDB2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-SF3B1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-SF3B2	Oncogene	OncoKBv20240704	Oncogene
-SFN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SFPQ	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SFRP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-SFRP2	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene, TumorSuppressorGene
-SFRP4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SFRP5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SGK1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-SGK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SGK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SGMS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SGSM2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SH2B3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SH2D1A	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SH3GL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SH3GLB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SHISA3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SHOC2	Oncogene	OncoKBv20240704	Oncogene
-SHOX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SHOX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SHPRH	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SHQ1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-SHTN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SIAH1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SIK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SIK1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-SIK1B	Kinase	PfamKinase, OncoKBv20240704	NA
-SIK2	Kinase	PfamKinase, OncoKBv20240704	NA
-SIK3	Kinase	PfamKinase, OncoKBv20240704	NA
-SIM1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SIM2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SIRPA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SIRT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SIRT2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SIRT3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SIRT4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SIRT6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SIX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-SIX2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-SIX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SIX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SIX5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SIX6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SKI	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-SKIL	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SKOR1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SKOR2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SKP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SLC2A4RG	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SLC34A2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SLC39A1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SLC39A4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SLC45A3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SLC5A8	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SLC9A3R1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SLFN11	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SLIT2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SLIT3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SLK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SLX4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-SMAD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SMAD2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SMAD3	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-SMAD4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-SMAD5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SMAD9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SMARCA2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-SMARCA4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SMARCB1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SMARCC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SMARCD1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SMARCE1	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-SMC1A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SMC3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SMCHD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SMG1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-SMO	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-SMYD3	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-SMYD4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SNAI1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SNAI2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SNAI3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SNAPC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SNAPC4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SNAPC5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SNCAIP	Oncogene	AddedallOnco_Feb2017.tsv, OncoKBv20240704	NA
-SND1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SNORD50A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SNRK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SNX29	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SOCS1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SOCS3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-SOD2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SOHLH1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOHLH2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SON	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOS1	Oncogene	OncoKBv20240704	Oncogene
-SOX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SOX10	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-SOX11	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SOX12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX13	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX14	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX15	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SOX17	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-SOX18	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX2	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-SOX21	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-SOX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX30	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX7	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SOX8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SOX9	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-SP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP100	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SP110	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP140	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-SP140L	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SP9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SPARC	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SPARCL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SPDEF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SPECC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SPEG	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SPEN	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-SPI1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-SPIB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SPIC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SPINK7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SPINT2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SPOP	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SPRED1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SPRTN	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-SPRY2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SPRY4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SPTBN1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SPZ1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SQSTM1	Oncogene	OncoKBv20240704	Oncogene
-SRC	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-SRCAP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SREBF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SREBF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SRF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SRGAP3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SRM	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SRMS	Kinase	PfamKinase, OncoKBv20240704	NA
-SRP72	Oncogene	OncoKBv20240704	Oncogene
-SRPK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SRPK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-SRPK2ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SRPK3	Kinase	PfamKinase, OncoKBv20240704	NA
-SRPX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SRSF2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SRSF3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SRY	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-SS18	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-SS18L1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SSBP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SSTK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SSX1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SSX2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-SSX4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ST13	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ST18	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ST20	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ST5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ST7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-STAG1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-STAG2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-STARD13	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-STAT1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-STAT2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-STAT3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-STAT4	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-STAT5A	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	Oncogene
-STAT5B	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-STAT6	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-STIL	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-STK10	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-STK11	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-STK16	Kinase	PfamKinase, OncoKBv20240704	NA
-STK17A	Kinase	PfamKinase, OncoKBv20240704	NA
-STK17B	Kinase	PfamKinase, OncoKBv20240704	NA
-STK19	Oncogene	OncoKBv20240704	Oncogene
-STK24	Kinase	PfamKinase, OncoKBv20240704	NA
-STK25	Kinase	PfamKinase, OncoKBv20240704	NA
-STK26	Kinase	PfamKinase, OncoKBv20240704	NA
-STK3	Kinase	PfamKinase, OncoKBv20240704	NA
-STK31	Kinase	PfamKinase, OncoKBv20240704	NA
-STK32A	Kinase	PfamKinase, OncoKBv20240704	NA
-STK32B	Kinase	PfamKinase, OncoKBv20240704	NA
-STK32C	Kinase	PfamKinase, OncoKBv20240704	NA
-STK33	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-STK33ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-STK35	Kinase	PfamKinase, OncoKBv20240704	NA
-STK36	Kinase	PfamKinase, OncoKBv20240704	NA
-STK38	Kinase	PfamKinase, OncoKBv20240704	NA
-STK38L	Kinase	PfamKinase, OncoKBv20240704	NA
-STK39	Kinase	PfamKinase, OncoKBv20240704	NA
-STK4	Kinase	PfamKinase, OncoKBv20240704	NA
-STK40	Kinase	PfamKinase, OncoKBv20240704	NA
-STKLD1	Kinase	PfamKinase, OncoKBv20240704	NA
-STLK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-STLK5	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-STLK6	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-STLK6-rs	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-STLK6ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-STRADA	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-STRADB	Kinase	PfamKinase, OncoKBv20240704	NA
-STRN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-STUB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-STYK1	Kinase	PfamKinase, OncoKBv20240704	NA
-SUFU	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SUZ12	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-SYK	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	Oncogene
-SYNM	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SYNPO2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SYT13	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-SgK050ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK069	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK071	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK085	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK110	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK196	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK223	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK269	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK288	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK307	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK384ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK396	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK424	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK493	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK494	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK495	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SgK496	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Slob	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-SuRTK106	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-T	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TAF1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704	Oncogene
-TAF15	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TAF1L	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TAGLN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TAK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TAL1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-TAL2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-TANK	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TAO1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TAO2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TAO3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TAOK1	Kinase	PfamKinase, OncoKBv20240704	NA
-TAOK2	Kinase	PfamKinase, OncoKBv20240704	NA
-TAOK3	Kinase	PfamKinase, OncoKBv20240704	NA
-TAT	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TBCK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TBK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TBL1XR1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TBL2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TBP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBPL1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBPL2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBR1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBRG1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TBX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX15	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX18	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX19	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX20	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX21	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX22	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX3	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TBX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBX5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TBX6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TBXT	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCEA1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TCEAL7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TCEB3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TCF12	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-TCF15	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCF20	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCF21	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCF23	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCF24	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCF3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TCF4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TCF7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCF7L1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-TCF7L1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCF7L2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TCF7L2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TCFL5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TCHP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TCL1A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TCL1B	Oncogene	OncoKBv20240704	Oncogene
-TDGF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TDRG1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TEAD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TEAD2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TEAD3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TEAD4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TEC	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-TEF	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TEK	Kinase	PfamKinase, OncoKBv20240704	NA
-TENT5C	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-TERB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TERF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TERF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TERT	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, AddedallOnco_Feb2017.tsv, OncoKBv20240704	Oncogene
-TES	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TESK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TESK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TET1	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TET2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TET3	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TEX14	Kinase	PfamKinase, OncoKBv20240704	NA
-TFAP2A	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TFAP2B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFAP2C	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFAP2D	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFAP2E	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFAP4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFCP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFCP2L1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFDP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFDP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFDP3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFE3	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-TFEB	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-TFEC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TFG	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TFPI2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TFPT	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TFRC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TGFB1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TGFBI	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TGFBR1	Kinase, TumorSuppressorGene	PfamKinase, OncoKBv20240704	TumorSuppressorGene
-TGFBR2	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	TumorSuppressorGene
-TGFBR3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TGFbR1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TGFbR2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TGIF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TGIF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TGIF2LX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TGIF2LY	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TGM3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-THAP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP11	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THAP9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-THBD	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-THBS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-THRA	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-THRAP3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-THRB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-THSD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-THY1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-THYN1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIE1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TIE2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TIF1a	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TIF1b	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TIF1g	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TIGAR	Oncogene	OncoKBv20240704	Oncogene
-TIGD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIGD2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIGD3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIGD4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIGD5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIGD6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIGD7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TIMP3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TLK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TLK1ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TLK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TLK2ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TLK2ps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TLX1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-TLX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TLX3	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene
-TMEFF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TMEFF2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TMEM127	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-TMF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TMPRSS11A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TMPRSS2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TMPRSS6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TNFAIP3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-TNFAIP8L2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNFRSF10A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNFRSF10B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNFRSF12A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNFRSF14	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-TNFRSF17	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TNFRSF18	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNFSF12	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNFSF13	Oncogene	OncoKBv20240704	Oncogene
-TNFSF9	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TNIK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TNK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704	NA
-TNK2	Kinase	PfamKinase, OncoKBv20240704	NA
-TNNI3K	Kinase	PfamKinase, OncoKBv20240704	NA
-TOM1L2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TOP1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TOP2A	Oncogene	OncoKBv20240704	Oncogene
-TOPORS	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TP53	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-TP53BP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-TP53BP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TP53COR1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TP53INP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TP63	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-TP73	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TPM3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TPM4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TPR	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TPRX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TPTE2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TPTEP2-CSNK1E	Kinase	PfamKinase, OncoKBv20240704	NA
-TRA	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TRAF3	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-TRAF5	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-TRAF7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TRAFD1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TRB	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TRD	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TRD-GTC9-1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TRERF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TREX2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRG	Oncogene	OncoKBv20240704	Oncogene
-TRIB1	Kinase	PfamKinase, OncoKBv20240704	NA
-TRIB2	Kinase	PfamKinase, OncoKBv20240704	NA
-TRIB3	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-TRIM13	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRIM15	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRIM24	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TRIM27	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TRIM3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRIM31	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRIM32	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRIM33	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TRIM35	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRIM62	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRIO	Kinase	PfamKinase, OncoKBv20240704	NA
-TRIP11	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-TRIP13	Oncogene, TumorSuppressorGene	OncoKBv20240704	Oncogene, TumorSuppressorGene
-TRIT1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TRKA	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TRKB	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TRKC	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TRPM6	Kinase	PfamKinase, OncoKBv20240704	NA
-TRPM7	Kinase	PfamKinase, OncoKBv20240704	NA
-TRPS1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TRRAP	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-TSC1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-TSC2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-TSC22D1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TSG101	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TSHR	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-TSHZ1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TSHZ2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TSHZ3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TSLP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TSPAN13	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TSPAN32	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TSSC4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TSSK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TSSK1B	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TSSK1B	Kinase	PfamKinase, OncoKBv20240704	NA
-TSSK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TSSK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TSSK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TSSK6	Kinase	PfamKinase, OncoKBv20240704	NA
-TSSKps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TSSKps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-TTBK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TTBK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TTC4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TTF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TTK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TTN	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TTYH1	Oncogene	AddedallOnco_Feb2017.tsv, OncoKBv20240704	NA
-TUSC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TUSC2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TUSC7	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TWIST1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-TWIST2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-TXK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TXNIP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-TYK2	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	Oncogene
-TYRO3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-TYRO3ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Trad	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Trb1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Trb2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Trb3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Trio	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-U2AF1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-UBA1	Oncogene	OncoKBv20240704	Oncogene
-UBE2A	Oncogene	OncoKBv20240704	Oncogene
-UBE2QL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UBE4B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UBIAD1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UBP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-UBR5	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-UBTF	Oncogene	OncoKBv20240704	Oncogene
-UCHL1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-UFL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UHMK1	Kinase	PfamKinase, OncoKBv20240704	NA
-UHRF2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UIMC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ULK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-ULK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-ULK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ULK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-UNC5A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UNC5B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UNC5C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UNC5D	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-UNCX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-USF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-USF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-USF3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-USP12	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-USP12P1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-USP33	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-USP44	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-USP6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-USP8	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-UVRAG	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-VACAMKL	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-VAV1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-VAV2	Oncogene	OncoKBv20240704	Oncogene
-VAX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-VAX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-VDR	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-VEGFA	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-VENTX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-VEZF1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-VEZT	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-VHL	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-VIL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-VIM	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-VPS53	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-VRK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-VRK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-VRK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-VRK3ps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-VSNL1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-VSX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-VSX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-VTI1A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-VTRNA2-1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-VWA5A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WAS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-WDCP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-WDR11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WDR48	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WEE1	Kinase	PfamKinase, OncoKBv20240704	NA
-WEE2	Kinase	PfamKinase, OncoKBv20240704	NA
-WFDC1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WHSC1L1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WIF1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-WISP3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WIZ	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-WNK1	Kinase	PfamKinase, OncoKBv20240704	NA
-WNK2	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704	NA
-WNK3	Kinase	PfamKinase, OncoKBv20240704	NA
-WNK4	Kinase	PfamKinase, OncoKBv20240704	NA
-WNT11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WNT5A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WNT7A	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WRN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-WT1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-WWOX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-WWP1	Oncogene	OncoKBv20240704	Oncogene
-WWTR1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-Wee1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wee1B	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wee1Bps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wee1ps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wee1ps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wnk1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wnk2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wnk3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-Wnk4	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-XAF1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-XBP1	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-XBP1P1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-XIAP	Oncogene	OncoKBv20240704	Oncogene
-XIST	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-XPA	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-XPC	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-XPO1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	Oncogene
-XPO5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-XRCC1	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-XRCC2	TumorSuppressorGene	OncoKBv20240704	TumorSuppressorGene
-XRCC5	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-YANK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-YANK2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-YANK3	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-YAP1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704	Oncogene
-YBX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-YBX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-YBX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-YES	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-YES1	Kinase, Oncogene	PfamKinase, OncoKBv20240704	Oncogene
-YESps	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-YPEL3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-YSK1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-YWHAE	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-YY1	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-YY2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZAK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-ZAP70	Kinase	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704	NA
-ZBED1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBED2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBED3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBED4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBED5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBED6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBED9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB11	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB14	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB16	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB17	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB18	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB20	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ZBTB21	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB22	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB24	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB25	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB26	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB32	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB33	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB34	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB37	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB38	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB39	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB40	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB41	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB42	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB43	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB44	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB45	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB46	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB47	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB48	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB49	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB6	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB7A	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	Oncogene, TumorSuppressorGene
-ZBTB7B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB7C	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB8A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB8B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZBTB9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZC3H10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZC3H8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZCCHC8	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ZDHHC2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZEB1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ZEB2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFAS1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZFAT	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFHX2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFHX3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ZFHX4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP14	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP28	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP30	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP36	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZFP36L1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-ZFP36L2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	TumorSuppressorGene
-ZFP36L2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ZFP37	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP41	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP42	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP57	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP62	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP64	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP69	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP69B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP82	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZFP90	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP91	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFP92	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFPM1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFPM2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFTA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFX	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZFY	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZGLP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZGPAT	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZHX1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZHX2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZHX3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZIC1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZIC2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZIC3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZIC4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZIC5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZIK1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZIM2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZIM3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZKSCAN1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZKSCAN2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZKSCAN3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZKSCAN4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZKSCAN5	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZKSCAN7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZKSCAN8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZMAT1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZMAT4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZMYM2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ZMYM3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ZMYND10	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZMYND11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZNF10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF100	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF101	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF107	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF112	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF114	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF117	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF121	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF124	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF131	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF132	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF133	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF134	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF135	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF136	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF138	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF14	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF140	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF141	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF142	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF143	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF146	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF148	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF154	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF155	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF157	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF16	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF160	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF165	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF169	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF17	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF174	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF175	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF177	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF18	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF180	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF181	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF182	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF184	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF185	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZNF189	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF19	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF195	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF197	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF20	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF200	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF202	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF205	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF207	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF208	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF211	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF212	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF213	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF214	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF215	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF217	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704	Oncogene
-ZNF219	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF22	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF221	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF222	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF223	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF224	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF225	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF226	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF227	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF229	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF23	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF230	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF232	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF233	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF234	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF235	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF236	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF239	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF24	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF248	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF25	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF250	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF251	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF253	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF254	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF256	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF257	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF26	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF260	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF263	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF264	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF266	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF267	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF268	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF273	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF274	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF275	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF276	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF277	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF28	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF280A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF280B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF280C	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF280D	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF281	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF282	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF283	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF284	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF285	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF286A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF286B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF287	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF292	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF296	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF30	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF300	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF302	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF304	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF311	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF316	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF317	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF318	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF319	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF32	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF320	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF322	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF322P1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF324	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF324B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF326	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF329	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF331	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF333	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF334	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF335	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF337	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF33A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF33B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF34	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF341	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF343	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF345	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF346	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF347	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF35	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF350	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF354A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF354B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF354C	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF358	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF362	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF365	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF366	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF367	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF37A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF382	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF383	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF384	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF385A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF385B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF385C	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF385D	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF391	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF394	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF395	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF396	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF397	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF398	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF404	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF407	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF408	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF41	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF410	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF414	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF415	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF416	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF417	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF418	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF419	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF420	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF423	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF425	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF426	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF428	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF429	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF43	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF430	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF431	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF432	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF433	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF436	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF438	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF439	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF44	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF440	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF441	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF442	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF443	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF444	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF445	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF446	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF449	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF45	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF451	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF454	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF460	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF461	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF462	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF467	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF468	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF469	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF470	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF471	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF473	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF474	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF479	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF48	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF480	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF483	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF484	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF485	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF486	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF487	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF488	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF490	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF491	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF492	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF493	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF496	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF497	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF500	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF501	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF502	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF503	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF506	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF507	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF510	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF511	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF512	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF512B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF513	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF514	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF516	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF517	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF518A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF518B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF519	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF521	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF524	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF525	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF526	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF527	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF528	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF529	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF530	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF532	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF534	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF536	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF540	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF541	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF543	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF544	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF546	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF547	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF548	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF549	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF550	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF551	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF552	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF554	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF555	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF556	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF557	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF558	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF559	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF560	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF561	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF562	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF563	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF564	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF565	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF566	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF567	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF568	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF569	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF57	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF570	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF571	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF572	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF573	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF574	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF575	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF576	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF577	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF578	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF579	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF580	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF581	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF582	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF583	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF584	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF585A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF585B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF586	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF587	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF587B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF589	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF592	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF594	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF595	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF596	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF597	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF598	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF599	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF600	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF605	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF606	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF607	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF608	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF609	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF610	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF611	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF613	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF614	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF615	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF616	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF618	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF619	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF620	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF621	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF623	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF624	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF625	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF626	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF627	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF628	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF629	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF630	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF639	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF641	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF644	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF645	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF646	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF648	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF649	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF652	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF653	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF654	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF655	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF658	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF66	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF660	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF662	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF664	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF665	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF667	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF668	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704	NA
-ZNF669	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF670	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF671	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF672	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF674	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF675	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF676	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF677	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF678	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF679	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF680	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF681	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF682	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF683	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF684	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF687	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF688	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF689	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF69	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF691	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF692	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF695	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF696	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF697	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF699	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF7	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF70	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF700	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF701	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF703	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF704	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF705A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF705B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF705D	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF705E	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF705EP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF705G	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF706	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF707	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF708	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF709	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF71	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF710	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF711	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF713	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF714	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF716	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF717	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF718	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF721	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF724	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF726	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF727	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF728	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF729	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF730	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF732	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF735	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF736	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF737	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF74	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF740	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF746	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF747	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF749	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF750	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704	TumorSuppressorGene
-ZNF75A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF75D	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF76	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF761	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF763	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF764	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF765	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF766	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF768	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF77	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF770	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF771	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF772	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF773	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF774	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF775	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF776	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF777	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF778	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF780A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF780B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF781	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF782	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF783	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF784	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF785	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF786	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF787	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF788	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF788P	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF789	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF79	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF790	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF791	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF792	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF793	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF799	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF8	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF80	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF800	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF804A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF804B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF805	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF808	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF81	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF813	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF814	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF816	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF821	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF823	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF827	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF829	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF83	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF830	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF831	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF835	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF836	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF837	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF84	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF841	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF843	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF844	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF845	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF846	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF85	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF850	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF852	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF853	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF860	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF865	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF875	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF878	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF879	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF880	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF883	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF888	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF891	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF90	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF91	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF92	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF93	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF98	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNF99	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZNRF3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	TumorSuppressorGene
-ZRSR2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704	NA
-ZSCAN1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN10	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN12	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN16	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN18	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN2	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN20	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN21	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN22	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN23	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN25	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN26	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN29	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN30	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN31	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN32	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN4	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN5A	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN5B	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN5C	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZSCAN9	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZUFSP	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZUP1	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZXDA	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZXDB	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZXDC	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-ZYX	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704	NA
-ZZZ3	TranscriptionFactor	addTF_JL.tsv, OncoKBv20240704	NA
-caMLCK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-eEF2K	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p38a	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p38b	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p38d	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p38g	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p70S6K	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p70S6Kb	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p70S6Kps1	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-p70S6Kps2	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-skMLCK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
-smMLCK	Kinase	Kincat_Hsap.08.02.txt, OncoKBv20240704	NA
+Gene_Symbol	type	file
+A1CF	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+AAK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+AATK	Kinase	PfamKinase
+ABCG2	TumorSuppressorGene	TumorSuppressorGene.txt
+ABI1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ABI2	TumorSuppressorGene	TumorSuppressorGene.txt
+ABL1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ABL2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ABRAXAS1	TumorSuppressorGene	OncoKBv20240704
+AC008770.3	TranscriptionFactor	addTF_JL.tsv
+AC023509.3	TranscriptionFactor	addTF_JL.tsv
+AC092835.1	TranscriptionFactor	addTF_JL.tsv
+AC138696.1	TranscriptionFactor	addTF_JL.tsv
+ACHE	TumorSuppressorGene	TumorSuppressorGene.txt
+ACK	Kinase	Kincat_Hsap.08.02.txt
+ACKR3	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ACSL3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ACSL6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ACTG1	TumorSuppressorGene	OncoKBv20240704
+ACTR2	Kinase	Kincat_Hsap.08.02.txt
+ACTR2B	Kinase	Kincat_Hsap.08.02.txt
+ACVR1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ACVR1B	Kinase, TumorSuppressorGene	PfamKinase, OncoKBv20240704
+ACVR1C	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+ACVR2A	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+ACVR2B	Kinase	PfamKinase
+ACVRL1	Kinase	PfamKinase
+ACY1	TumorSuppressorGene	TumorSuppressorGene.txt
+ADAMTS18	TumorSuppressorGene	TumorSuppressorGene.txt
+ADAMTS8	TumorSuppressorGene	TumorSuppressorGene.txt
+ADAMTS9	TumorSuppressorGene	TumorSuppressorGene.txt
+ADAMTS9-AS2	TumorSuppressorGene	TumorSuppressorGene.txt
+ADARB1	TumorSuppressorGene	TumorSuppressorGene.txt
+ADCK1	Kinase	Kincat_Hsap.08.02.txt
+ADCK2	Kinase	Kincat_Hsap.08.02.txt
+ADCK3	Kinase	Kincat_Hsap.08.02.txt
+ADCK4	Kinase	Kincat_Hsap.08.02.txt
+ADCK5	Kinase	Kincat_Hsap.08.02.txt
+ADHFE1	Oncogene	OncoKBv20240704
+ADNP	TranscriptionFactor	addTF_JL.tsv
+ADNP2	TranscriptionFactor	addTF_JL.tsv
+ADPRH	TumorSuppressorGene	TumorSuppressorGene.txt
+AEBP1	TranscriptionFactor	addTF_JL.tsv
+AEBP2	TranscriptionFactor	addTF_JL.tsv
+AFAP1L2	TumorSuppressorGene	TumorSuppressorGene.txt
+AFDN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+AFF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+AFF3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+AFF4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+AGO1	Oncogene	OncoKBv20240704
+AGTR1	TumorSuppressorGene	TumorSuppressorGene.txt
+AHCTF1	TranscriptionFactor	addTF_JL.tsv
+AHCYL1	TumorSuppressorGene	TumorSuppressorGene.txt
+AHDC1	TranscriptionFactor	addTF_JL.tsv
+AHNAK	TumorSuppressorGene	TumorSuppressorGene.txt
+AHR	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+AHRR	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+AIF1	TumorSuppressorGene	TumorSuppressorGene.txt
+AIM2	TumorSuppressorGene	TumorSuppressorGene.txt
+AIMP1	TumorSuppressorGene	TumorSuppressorGene.txt
+AIMP2	TumorSuppressorGene	TumorSuppressorGene.txt
+AIP	TumorSuppressorGene	TumorSuppressorGene.txt
+AIRE	TranscriptionFactor	addTF_JL.tsv
+AJAP1	TumorSuppressorGene	TumorSuppressorGene.txt
+AJUBA	TumorSuppressorGene	OncoKBv20240704
+AKAP12	TumorSuppressorGene	TumorSuppressorGene.txt
+AKAP8	TranscriptionFactor	addTF_JL.tsv
+AKAP8L	TranscriptionFactor	addTF_JL.tsv
+AKAP9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+AKNA	TranscriptionFactor	addTF_JL.tsv
+AKR1B1	TumorSuppressorGene	TumorSuppressorGene.txt
+AKT1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+AKT2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+AKT3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ALDH18A1	Kinase	PfamKinase
+ALDH1A2	TumorSuppressorGene	TumorSuppressorGene.txt
+ALDH1L2	Oncogene	OncoKBv20240704
+ALDH2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ALK	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ALK1	Kinase	Kincat_Hsap.08.02.txt
+ALK2	Kinase	Kincat_Hsap.08.02.txt
+ALK4	Kinase	Kincat_Hsap.08.02.txt
+ALK7	Kinase	Kincat_Hsap.08.02.txt
+ALOX12B	Oncogene, TumorSuppressorGene	OncoKBv20240704
+ALOX15	TumorSuppressorGene	TumorSuppressorGene.txt
+ALOX15B	TumorSuppressorGene	TumorSuppressorGene.txt
+ALPK1	Kinase	PfamKinase
+ALPK2	Kinase	PfamKinase
+ALPK3	Kinase	PfamKinase
+ALPL	TumorSuppressorGene	TumorSuppressorGene.txt
+ALX1	TranscriptionFactor	addTF_JL.tsv
+ALX3	TranscriptionFactor	addTF_JL.tsv
+ALX4	TranscriptionFactor	addTF_JL.tsv
+AMER1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+AMH	TumorSuppressorGene	TumorSuppressorGene.txt
+AMHR2	Kinase	PfamKinase
+AMPKa1	Kinase	Kincat_Hsap.08.02.txt
+AMPKa2	Kinase	Kincat_Hsap.08.02.txt
+ANAPC1	TumorSuppressorGene	TumorSuppressorGene.txt
+ANGPTL4	TumorSuppressorGene	TumorSuppressorGene.txt
+ANHX	TranscriptionFactor	addTF_JL.tsv
+ANK1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ANKK1	Kinase	PfamKinase
+ANKRD11	TumorSuppressorGene	OncoKBv20240704
+ANKRD26	Oncogene	OncoKBv20240704
+ANKRD3	Kinase	Kincat_Hsap.08.02.txt
+ANKZF1	TranscriptionFactor	addTF_JL.tsv
+ANP32A	TumorSuppressorGene	TumorSuppressorGene.txt
+ANPa	Kinase	Kincat_Hsap.08.02.txt
+ANPb	Kinase	Kincat_Hsap.08.02.txt
+ANXA1	TumorSuppressorGene	TumorSuppressorGene.txt
+ANXA7	TumorSuppressorGene	TumorSuppressorGene.txt
+APAF1	TumorSuppressorGene	TumorSuppressorGene.txt
+APC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+APITD1	TumorSuppressorGene	TumorSuppressorGene.txt
+APLNR	Oncogene, TumorSuppressorGene	OncoKBv20240704
+APOBEC3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+AR	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ARAF	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ARAFps	Kinase	Kincat_Hsap.08.02.txt
+ARF1	TumorSuppressorGene	TumorSuppressorGene.txt
+ARG1	TumorSuppressorGene	TumorSuppressorGene.txt
+ARGFX	TranscriptionFactor	addTF_JL.tsv
+ARHGAP26	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ARHGAP29	TumorSuppressorGene	TumorSuppressorGene.txt
+ARHGAP35	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+ARHGAP5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ARHGEF10	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ARHGEF10L	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ARHGEF12	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ARHGEF28	Oncogene	OncoKBv20240704
+ARID1A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ARID1B	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ARID2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ARID3A	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+ARID3B	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+ARID3C	TranscriptionFactor	addTF_JL.tsv
+ARID4A	TumorSuppressorGene	OncoKBv20240704
+ARID4B	TumorSuppressorGene	OncoKBv20240704
+ARID5A	TranscriptionFactor	addTF_JL.tsv
+ARID5B	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+ARL11	TumorSuppressorGene	TumorSuppressorGene.txt
+ARL6IP5	TumorSuppressorGene	TumorSuppressorGene.txt
+ARMC10	TumorSuppressorGene	TumorSuppressorGene.txt
+ARMC5	TumorSuppressorGene	TumorSuppressorGene.txt
+ARNT	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ARNT2	TranscriptionFactor	addTF_JL.tsv
+ARNTL	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ARNTL2	TranscriptionFactor	addTF_JL.tsv
+ARX	TranscriptionFactor	addTF_JL.tsv
+ASCL1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ASCL2	TranscriptionFactor	addTF_JL.tsv
+ASCL3	TranscriptionFactor	addTF_JL.tsv
+ASCL4	TranscriptionFactor	addTF_JL.tsv
+ASCL5	TranscriptionFactor	addTF_JL.tsv
+ASH1L	TranscriptionFactor	addTF_JL.tsv
+ASPSCR1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ASS1	TumorSuppressorGene	TumorSuppressorGene.txt
+ASXL1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ASXL2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ATF1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ATF2	TranscriptionFactor	addTF_JL.tsv
+ATF3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ATF4	TranscriptionFactor	addTF_JL.tsv
+ATF5	TranscriptionFactor	addTF_JL.tsv
+ATF6	TranscriptionFactor	addTF_JL.tsv
+ATF6B	TranscriptionFactor	addTF_JL.tsv
+ATF7	TranscriptionFactor	addTF_JL.tsv
+ATIC	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ATM	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ATMIN	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ATOH1	TranscriptionFactor	addTF_JL.tsv
+ATOH7	TranscriptionFactor	addTF_JL.tsv
+ATOH8	TranscriptionFactor	addTF_JL.tsv
+ATP1A1	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ATP2B3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ATP6V1B2	TumorSuppressorGene	OncoKBv20240704
+ATR	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ATRIP	TumorSuppressorGene	OncoKBv20240704
+ATRX	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ATXN2	TumorSuppressorGene	OncoKBv20240704
+ATXN7	Oncogene	OncoKBv20240704
+AURKA	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+AURKB	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+AURKC	Kinase	PfamKinase
+AXIN1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+AXIN2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+AXL	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+AZGP1	TumorSuppressorGene	TumorSuppressorGene.txt
+AlphaK1	Kinase	Kincat_Hsap.08.02.txt
+AlphaK2	Kinase	Kincat_Hsap.08.02.txt
+AlphaK3	Kinase	Kincat_Hsap.08.02.txt
+AurA	Kinase	Kincat_Hsap.08.02.txt
+AurAps1	Kinase	Kincat_Hsap.08.02.txt
+AurAps2	Kinase	Kincat_Hsap.08.02.txt
+AurB	Kinase	Kincat_Hsap.08.02.txt
+AurBps1	Kinase	Kincat_Hsap.08.02.txt
+AurC	Kinase	Kincat_Hsap.08.02.txt
+B2M	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BAALC	Oncogene	OncoKBv20240704
+BACH1	TranscriptionFactor	addTF_JL.tsv
+BACH2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+BANP	TumorSuppressorGene	TumorSuppressorGene.txt
+BAP1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BARD1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BARHL1	TranscriptionFactor	addTF_JL.tsv
+BARHL2	TranscriptionFactor	addTF_JL.tsv
+BARK1	Kinase	Kincat_Hsap.08.02.txt
+BARK2	Kinase	Kincat_Hsap.08.02.txt
+BARX1	TranscriptionFactor	addTF_JL.tsv
+BARX2	TranscriptionFactor	addTF_JL.tsv
+BASP1	TumorSuppressorGene	TumorSuppressorGene.txt
+BATF	TranscriptionFactor	addTF_JL.tsv
+BATF2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+BATF3	TranscriptionFactor	addTF_JL.tsv
+BAX	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+BAZ1A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BAZ2A	TranscriptionFactor	addTF_JL.tsv
+BAZ2B	TranscriptionFactor	addTF_JL.tsv
+BBC3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+BBX	TranscriptionFactor	addTF_JL.tsv
+BCKDK	Kinase	Kincat_Hsap.08.02.txt
+BCL10	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BCL11A	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+BCL11B	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+BCL2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BCL2L11	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+BCL2L12	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BCL3	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BCL6	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+BCL6B	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+BCL7A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BCL9	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BCL9L	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BCLAF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BCOR	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BCORL1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BCR	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BECN1	TumorSuppressorGene	TumorSuppressorGene.txt
+BEX2	TumorSuppressorGene	TumorSuppressorGene.txt
+BHLHA15	TranscriptionFactor	addTF_JL.tsv
+BHLHA9	TranscriptionFactor	addTF_JL.tsv
+BHLHE22	TranscriptionFactor	addTF_JL.tsv
+BHLHE23	TranscriptionFactor	addTF_JL.tsv
+BHLHE40	TranscriptionFactor	addTF_JL.tsv
+BHLHE41	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+BICRA	TumorSuppressorGene	TumorSuppressorGene.txt
+BIK	TumorSuppressorGene	TumorSuppressorGene.txt
+BIKE	Kinase	Kincat_Hsap.08.02.txt
+BIN1	TumorSuppressorGene	TumorSuppressorGene.txt
+BIRC3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BIRC6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BLCAP	TumorSuppressorGene	TumorSuppressorGene.txt
+BLID	TumorSuppressorGene	TumorSuppressorGene.txt
+BLK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+BLM	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BLNK	TumorSuppressorGene	TumorSuppressorGene.txt
+BMAL1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+BMAL2	TranscriptionFactor	addTF_JL.tsv
+BMF	TumorSuppressorGene	TumorSuppressorGene.txt
+BMP10	TumorSuppressorGene	TumorSuppressorGene.txt
+BMP2	TumorSuppressorGene	TumorSuppressorGene.txt
+BMP2K	Kinase	PfamKinase
+BMP4	TumorSuppressorGene	TumorSuppressorGene.txt
+BMP5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BMPR1A	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+BMPR1Aps1	Kinase	Kincat_Hsap.08.02.txt
+BMPR1Aps2	Kinase	Kincat_Hsap.08.02.txt
+BMPR1B	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+BMPR2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+BMX	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+BNC1	TranscriptionFactor	addTF_JL.tsv
+BNC2	TranscriptionFactor	addTF_JL.tsv
+BNIP3L	TumorSuppressorGene	TumorSuppressorGene.txt
+BORCS8-MEF2B	TranscriptionFactor	addTF_JL.tsv
+BPTF	TranscriptionFactor	addTF_JL.tsv
+BRAF	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+BRAFps	Kinase	Kincat_Hsap.08.02.txt
+BRCA1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BRCA2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BRD2	Kinase	Kincat_Hsap.08.02.txt
+BRD3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BRD4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BRD7	TumorSuppressorGene	TumorSuppressorGene.txt
+BRDT	Kinase	Kincat_Hsap.08.02.txt
+BRF1	TumorSuppressorGene	TumorSuppressorGene.txt
+BRF2	TranscriptionFactor	addTF_JL.tsv
+BRINP1	TumorSuppressorGene	TumorSuppressorGene.txt
+BRIP1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BRK	Kinase	Kincat_Hsap.08.02.txt
+BRMS1	TumorSuppressorGene	TumorSuppressorGene.txt
+BRMS1L	TumorSuppressorGene	TumorSuppressorGene.txt
+BRSK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704
+BRSK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+BSX	TranscriptionFactor	addTF_JL.tsv
+BTG1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+BTG2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+BTG3	TumorSuppressorGene	TumorSuppressorGene.txt
+BTG4	TumorSuppressorGene	TumorSuppressorGene.txt
+BTK	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+BUB1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+BUB1B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+BUBR1	Kinase	Kincat_Hsap.08.02.txt
+C11orf95	TranscriptionFactor	addTF_JL.tsv
+C15orf65	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+C2orf40	TumorSuppressorGene	TumorSuppressorGene.txt
+CABLES1	TumorSuppressorGene	TumorSuppressorGene.txt
+CACNA1D	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CACNA2D3	TumorSuppressorGene	TumorSuppressorGene.txt
+CAD	Oncogene	OncoKBv20240704
+CADM1	TumorSuppressorGene	TumorSuppressorGene.txt
+CADM2	TumorSuppressorGene	TumorSuppressorGene.txt
+CADM3	TumorSuppressorGene	TumorSuppressorGene.txt
+CADM4	TumorSuppressorGene	TumorSuppressorGene.txt
+CALR	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CAMK1	Kinase	PfamKinase
+CAMK1D	Kinase	PfamKinase
+CAMK1G	Kinase	PfamKinase
+CAMK2A	Kinase	PfamKinase
+CAMK2B	Kinase	PfamKinase
+CAMK2D	Kinase	PfamKinase
+CAMK2G	Kinase	PfamKinase
+CAMK2N1	TumorSuppressorGene	TumorSuppressorGene.txt
+CAMK4	Kinase	PfamKinase
+CAMKK1	Kinase	PfamKinase
+CAMKK2	Kinase	PfamKinase
+CAMKV	Kinase	PfamKinase
+CAMTA1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+CAMTA2	TranscriptionFactor	addTF_JL.tsv
+CANT1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CAPG	TumorSuppressorGene	TumorSuppressorGene.txt
+CARD11	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CARF	TranscriptionFactor	addTF_JL.tsv
+CARS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CARS1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CASC1	TumorSuppressorGene	TumorSuppressorGene.txt
+CASC2	TumorSuppressorGene	TumorSuppressorGene.txt
+CASK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CASP2	TumorSuppressorGene	TumorSuppressorGene.txt
+CASP3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CASP5	TumorSuppressorGene	TumorSuppressorGene.txt
+CASP8	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CASP9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CASZ1	TranscriptionFactor	addTF_JL.tsv
+CAT	TumorSuppressorGene	TumorSuppressorGene.txt
+CAV1	TumorSuppressorGene	TumorSuppressorGene.txt
+CAVIN3	TumorSuppressorGene	TumorSuppressorGene.txt
+CBFA2T3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CBFB	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CBL	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CBLB	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CBLC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CBLL2	TranscriptionFactor	addTF_JL.tsv
+CBX2	TranscriptionFactor	addTF_JL.tsv
+CBX5	TumorSuppressorGene	TumorSuppressorGene.txt
+CC2D1A	TranscriptionFactor	addTF_JL.tsv
+CCAR1	TumorSuppressorGene	TumorSuppressorGene.txt
+CCAR2	TumorSuppressorGene	TumorSuppressorGene.txt
+CCDC136	TumorSuppressorGene	TumorSuppressorGene.txt
+CCDC154	TumorSuppressorGene	TumorSuppressorGene.txt
+CCDC169-SOHLH2	TranscriptionFactor	addTF_JL.tsv
+CCDC17	TranscriptionFactor	addTF_JL.tsv
+CCDC6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CCDC67	TumorSuppressorGene	TumorSuppressorGene.txt
+CCK4	Kinase	Kincat_Hsap.08.02.txt
+CCN2	TumorSuppressorGene	TumorSuppressorGene.txt
+CCN3	TumorSuppressorGene	TumorSuppressorGene.txt
+CCN6	TumorSuppressorGene	TumorSuppressorGene.txt
+CCNB1IP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CCNB3	Oncogene	OncoKBv20240704
+CCNC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+CCND1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CCND2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CCND3	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CCNDBP1	TumorSuppressorGene	TumorSuppressorGene.txt
+CCNE1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CCNQ	TumorSuppressorGene	OncoKBv20240704
+CCR4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CCR7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CCRK	Kinase	Kincat_Hsap.08.02.txt
+CD19	Oncogene	OncoKBv20240704
+CD209	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CD274	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CD276	Oncogene	OncoKBv20240704
+CD28	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CD4	TumorSuppressorGene	TumorSuppressorGene.txt
+CD44	TumorSuppressorGene	TumorSuppressorGene.txt
+CD58	TumorSuppressorGene	OncoKBv20240704
+CD70	Oncogene	OncoKBv20240704
+CD74	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CD79A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CD79B	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CD82	TumorSuppressorGene	TumorSuppressorGene.txt
+CDC2	Kinase	Kincat_Hsap.08.02.txt
+CDC42	Oncogene	OncoKBv20240704
+CDC42BPA	Kinase	PfamKinase
+CDC42BPB	Kinase	PfamKinase
+CDC42BPG	Kinase	PfamKinase
+CDC5L	TranscriptionFactor	addTF_JL.tsv
+CDC7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDC73	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CDCP1	TumorSuppressorGene	TumorSuppressorGene.txt
+CDH1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CDH10	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CDH11	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CDH13	TumorSuppressorGene	TumorSuppressorGene.txt
+CDH17	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+CDH2	Oncogene	OncoKBv20240704
+CDH4	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+CDH5	TumorSuppressorGene	TumorSuppressorGene.txt
+CDK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDK10	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDK11	Kinase	Kincat_Hsap.08.02.txt
+CDK11A	Kinase	PfamKinase
+CDK11B	Kinase	PfamKinase
+CDK12	CosmicCensus, Kinase, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+CDK13	Kinase	PfamKinase
+CDK14	Kinase	PfamKinase
+CDK15	Kinase	PfamKinase
+CDK16	Kinase	PfamKinase
+CDK17	Kinase	PfamKinase
+CDK18	Kinase	PfamKinase
+CDK19	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+CDK20	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDK2AP1	TumorSuppressorGene	TumorSuppressorGene.txt
+CDK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDK4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+CDK4ps	Kinase	Kincat_Hsap.08.02.txt
+CDK5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDK5ps	Kinase	Kincat_Hsap.08.02.txt
+CDK6	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+CDK7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDK7ps	Kinase	Kincat_Hsap.08.02.txt
+CDK8	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+CDK8ps	Kinase	Kincat_Hsap.08.02.txt
+CDK9	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDKL1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDKL2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDKL3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDKL4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDKL5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CDKN1A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CDKN1B	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CDKN1C	TumorSuppressorGene	TumorSuppressorGene.txt
+CDKN2A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CDKN2B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+CDKN2C	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CDO1	TumorSuppressorGene	TumorSuppressorGene.txt
+CDX1	TranscriptionFactor	addTF_JL.tsv
+CDX2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+CDX4	TranscriptionFactor	addTF_JL.tsv
+CEACAM1	TumorSuppressorGene	TumorSuppressorGene.txt
+CEBPA	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+CEBPB	TranscriptionFactor	addTF_JL.tsv
+CEBPD	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+CEBPE	TranscriptionFactor	addTF_JL.tsv
+CEBPG	TranscriptionFactor	addTF_JL.tsv
+CEBPZ	TranscriptionFactor	addTF_JL.tsv
+CENPA	TranscriptionFactor	addTF_JL.tsv
+CENPB	TranscriptionFactor	addTF_JL.tsv
+CENPBD1	TranscriptionFactor	addTF_JL.tsv
+CENPBD1P	TranscriptionFactor	addTF_JL.tsv
+CENPS	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+CENPT	TranscriptionFactor	addTF_JL.tsv
+CENPX	TranscriptionFactor	addTF_JL.tsv
+CEP43	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CEP89	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CFTR	TumorSuppressorGene	TumorSuppressorGene.txt
+CGDps	Kinase	Kincat_Hsap.08.02.txt
+CGGBP1	TranscriptionFactor	addTF_JL.tsv
+CHAMP1	TranscriptionFactor	addTF_JL.tsv
+CHCHD3	TranscriptionFactor	addTF_JL.tsv
+CHCHD7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CHD1	TumorSuppressorGene	TumorSuppressorGene.txt
+CHD2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CHD4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CHD5	TumorSuppressorGene	TumorSuppressorGene.txt
+CHED	Kinase	Kincat_Hsap.08.02.txt
+CHEK1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704
+CHEK2	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+CHFR	TumorSuppressorGene	TumorSuppressorGene.txt
+CHIC2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CHK1	Kinase	Kincat_Hsap.08.02.txt
+CHK2	Kinase	Kincat_Hsap.08.02.txt
+CHK2ps1	Kinase	Kincat_Hsap.08.02.txt
+CHK2ps2	Kinase	Kincat_Hsap.08.02.txt
+CHKA	Kinase	PfamKinase
+CHKB	Kinase	PfamKinase
+CHST10	TumorSuppressorGene	TumorSuppressorGene.txt
+CHST11	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CHTF8	TumorSuppressorGene	OncoKBv20240704
+CHUK	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+CIC	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+CIITA	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CILK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CIT	Kinase	PfamKinase
+CITED2	TumorSuppressorGene	TumorSuppressorGene.txt
+CIZ1	TumorSuppressorGene	TumorSuppressorGene.txt
+CK1a	Kinase	Kincat_Hsap.08.02.txt
+CK1a2	Kinase	Kincat_Hsap.08.02.txt
+CK1aps1	Kinase	Kincat_Hsap.08.02.txt
+CK1aps2	Kinase	Kincat_Hsap.08.02.txt
+CK1aps3	Kinase	Kincat_Hsap.08.02.txt
+CK1d	Kinase	Kincat_Hsap.08.02.txt
+CK1e	Kinase	Kincat_Hsap.08.02.txt
+CK1g1	Kinase	Kincat_Hsap.08.02.txt
+CK1g2	Kinase	Kincat_Hsap.08.02.txt
+CK1g2ps	Kinase	Kincat_Hsap.08.02.txt
+CK1g3	Kinase	Kincat_Hsap.08.02.txt
+CK2a1	Kinase	Kincat_Hsap.08.02.txt
+CK2a1-rs	Kinase	Kincat_Hsap.08.02.txt
+CK2a2	Kinase	Kincat_Hsap.08.02.txt
+CLDN1	TumorSuppressorGene	TumorSuppressorGene.txt
+CLDN23	TumorSuppressorGene	TumorSuppressorGene.txt
+CLIK1	Kinase	Kincat_Hsap.08.02.txt
+CLIK1L	Kinase	Kincat_Hsap.08.02.txt
+CLIP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CLK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CLK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CLK2ps	Kinase	Kincat_Hsap.08.02.txt
+CLK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CLK3ps	Kinase	Kincat_Hsap.08.02.txt
+CLK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CLOCK	TranscriptionFactor	addTF_JL.tsv
+CLP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CLTC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CLTCL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CLU	TumorSuppressorGene	TumorSuppressorGene.txt
+CMC4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CMTM3	TumorSuppressorGene	TumorSuppressorGene.txt
+CMTM5	TumorSuppressorGene	TumorSuppressorGene.txt
+CMTR2	TumorSuppressorGene	OncoKBv20240704
+CNBD1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CNBP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CNDP2	TumorSuppressorGene	TumorSuppressorGene.txt
+CNN1	TumorSuppressorGene	TumorSuppressorGene.txt
+CNOT3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+CNTNAP2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+CNTRL	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+COL1A1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+COL2A1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+COL3A1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+COP1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+COPS2	TumorSuppressorGene	TumorSuppressorGene.txt
+COQ8A	Kinase	Kincat_Hsap.08.02.txt
+COQ8B	Kinase	Kincat_Hsap.08.02.txt
+COT	Kinase	Kincat_Hsap.08.02.txt
+COX6C	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CPEB1	TranscriptionFactor	addTF_JL.tsv
+CPEB3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CPNE7	TumorSuppressorGene	TumorSuppressorGene.txt
+CPXCR1	TranscriptionFactor	addTF_JL.tsv
+CRBN	TumorSuppressorGene	OncoKBv20240704
+CREB1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+CREB3	TranscriptionFactor	addTF_JL.tsv
+CREB3L1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+CREB3L2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+CREB3L3	TranscriptionFactor	addTF_JL.tsv
+CREB3L4	TranscriptionFactor	addTF_JL.tsv
+CREB5	TranscriptionFactor	addTF_JL.tsv
+CREBBP	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CREBL2	TranscriptionFactor	addTF_JL.tsv
+CREBZF	TranscriptionFactor	addTF_JL.tsv
+CREM	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+CRIK	Kinase	Kincat_Hsap.08.02.txt
+CRK7	Kinase	Kincat_Hsap.08.02.txt
+CRKL	Oncogene	OncoKBv20240704
+CRLF2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CRNKL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CRNN	TumorSuppressorGene	TumorSuppressorGene.txt
+CRTC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CRTC3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CRX	TranscriptionFactor	addTF_JL.tsv
+CSF1R	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+CSF2	TumorSuppressorGene	TumorSuppressorGene.txt
+CSF3R	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CSK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+CSMD1	TumorSuppressorGene	TumorSuppressorGene.txt
+CSMD3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CSNK1A1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+CSNK1A1L	Kinase	PfamKinase
+CSNK1D	Kinase	PfamKinase
+CSNK1E	Kinase	PfamKinase
+CSNK1G1	Kinase	PfamKinase
+CSNK1G2	Kinase	PfamKinase
+CSNK1G3	Kinase	PfamKinase
+CSNK2A1	Kinase	PfamKinase
+CSNK2A2	Kinase	PfamKinase
+CSNK2A3	Kinase	PfamKinase
+CSRNP1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+CSRNP2	TranscriptionFactor	addTF_JL.tsv
+CSRNP3	TranscriptionFactor	addTF_JL.tsv
+CST5	TumorSuppressorGene	TumorSuppressorGene.txt
+CST6	TumorSuppressorGene	TumorSuppressorGene.txt
+CTCF	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+CTCFL	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+CTDSPL	TumorSuppressorGene	TumorSuppressorGene.txt
+CTGF	TumorSuppressorGene	TumorSuppressorGene.txt
+CTK	Kinase	Kincat_Hsap.08.02.txt
+CTLA4	Oncogene	OncoKBv20240704
+CTNNA1	TumorSuppressorGene	OncoKBv20240704
+CTNNA2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+CTNNA3	TumorSuppressorGene	TumorSuppressorGene.txt
+CTNNB1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CTNNBIP1	TumorSuppressorGene	TumorSuppressorGene.txt
+CTNND1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+CTNND2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CTR9	TumorSuppressorGene	OncoKBv20240704
+CUL1	TumorSuppressorGene	TumorSuppressorGene.txt
+CUL2	TumorSuppressorGene	TumorSuppressorGene.txt
+CUL3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CUL4A	Oncogene	OncoKBv20240704
+CUL5	TumorSuppressorGene	TumorSuppressorGene.txt
+CUX1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+CUX2	TranscriptionFactor	addTF_JL.tsv
+CXCL10	TumorSuppressorGene	TumorSuppressorGene.txt
+CXCL12	TumorSuppressorGene	TumorSuppressorGene.txt
+CXCL14	TumorSuppressorGene	TumorSuppressorGene.txt
+CXCR2	TumorSuppressorGene	TumorSuppressorGene.txt
+CXCR4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CXXC1	TranscriptionFactor	addTF_JL.tsv
+CXXC4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+CXXC5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+CYB561D2	TumorSuppressorGene	TumorSuppressorGene.txt
+CYB5A	TumorSuppressorGene	TumorSuppressorGene.txt
+CYB5R2	TumorSuppressorGene	TumorSuppressorGene.txt
+CYGB	TumorSuppressorGene	TumorSuppressorGene.txt
+CYGD	Kinase	Kincat_Hsap.08.02.txt
+CYGF	Kinase	Kincat_Hsap.08.02.txt
+CYLD	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CYP19A1	Oncogene	OncoKBv20240704
+CYP2C8	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+CYSLTR2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+CaMK1a	Kinase	Kincat_Hsap.08.02.txt
+CaMK1b	Kinase	Kincat_Hsap.08.02.txt
+CaMK1d	Kinase	Kincat_Hsap.08.02.txt
+CaMK1g	Kinase	Kincat_Hsap.08.02.txt
+CaMK2a	Kinase	Kincat_Hsap.08.02.txt
+CaMK2b	Kinase	Kincat_Hsap.08.02.txt
+CaMK2d	Kinase	Kincat_Hsap.08.02.txt
+CaMK2g	Kinase	Kincat_Hsap.08.02.txt
+CaMK4	Kinase	Kincat_Hsap.08.02.txt
+CaMKK1	Kinase	Kincat_Hsap.08.02.txt
+CaMKK2	Kinase	Kincat_Hsap.08.02.txt
+ChaK1	Kinase	Kincat_Hsap.08.02.txt
+ChaK2	Kinase	Kincat_Hsap.08.02.txt
+DAB2	TumorSuppressorGene	TumorSuppressorGene.txt
+DAB2IP	TumorSuppressorGene	TumorSuppressorGene.txt
+DACH1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+DACH2	TranscriptionFactor	addTF_JL.tsv
+DACT1	TumorSuppressorGene	TumorSuppressorGene.txt
+DAPK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+DAPK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+DAPK3	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+DAXX	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DBP	TranscriptionFactor	addTF_JL.tsv
+DBX1	TranscriptionFactor	addTF_JL.tsv
+DBX2	TranscriptionFactor	addTF_JL.tsv
+DCAF12L2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+DCC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+DCDC2	TumorSuppressorGene	TumorSuppressorGene.txt
+DCLK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DCLK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DCLK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DCLRE1A	TumorSuppressorGene	TumorSuppressorGene.txt
+DCN	TumorSuppressorGene	TumorSuppressorGene.txt
+DCTN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+DCUN1D1	Oncogene	OncoKBv20240704
+DCUN1D3	TumorSuppressorGene	TumorSuppressorGene.txt
+DDB2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DDIT3	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+DDR1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DDR2	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+DDX10	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+DDX3X	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DDX4	Oncogene	OncoKBv20240704
+DDX41	TumorSuppressorGene	OncoKBv20240704
+DDX5	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DDX58	TumorSuppressorGene	TumorSuppressorGene.txt
+DDX6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+DEAF1	TranscriptionFactor	addTF_JL.tsv
+DEFB1	TumorSuppressorGene	TumorSuppressorGene.txt
+DEK	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DENND2B	TumorSuppressorGene	TumorSuppressorGene.txt
+DENND2D	TumorSuppressorGene	TumorSuppressorGene.txt
+DEUP1	TumorSuppressorGene	TumorSuppressorGene.txt
+DFFA	TumorSuppressorGene	TumorSuppressorGene.txt
+DFNA5	TumorSuppressorGene	TumorSuppressorGene.txt
+DGCR8	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+DGKA	Kinase	PfamKinase
+DGKB	Kinase	PfamKinase
+DGKG	Kinase	PfamKinase
+DIABLO	TumorSuppressorGene	TumorSuppressorGene.txt
+DICER1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DIDO1	TumorSuppressorGene	TumorSuppressorGene.txt
+DIRAS1	TumorSuppressorGene	TumorSuppressorGene.txt
+DIRAS3	TumorSuppressorGene	TumorSuppressorGene.txt
+DIS3	TumorSuppressorGene	OncoKBv20240704
+DKK1	TumorSuppressorGene	TumorSuppressorGene.txt
+DKK3	TumorSuppressorGene	TumorSuppressorGene.txt
+DLC1	TumorSuppressorGene	TumorSuppressorGene.txt
+DLEC1	TumorSuppressorGene	TumorSuppressorGene.txt
+DLEU1	TumorSuppressorGene	TumorSuppressorGene.txt
+DLEU2	TumorSuppressorGene	TumorSuppressorGene.txt
+DLG1	TumorSuppressorGene	TumorSuppressorGene.txt
+DLK	Kinase	Kincat_Hsap.08.02.txt
+DLK1	TumorSuppressorGene	TumorSuppressorGene.txt
+DLX1	TranscriptionFactor	addTF_JL.tsv
+DLX2	TranscriptionFactor	addTF_JL.tsv
+DLX3	TranscriptionFactor	addTF_JL.tsv
+DLX4	TranscriptionFactor	addTF_JL.tsv
+DLX5	TranscriptionFactor	addTF_JL.tsv
+DLX6	TranscriptionFactor	addTF_JL.tsv
+DMBT1	TumorSuppressorGene	TumorSuppressorGene.txt
+DMBX1	TranscriptionFactor	addTF_JL.tsv
+DMD	TumorSuppressorGene	TumorSuppressorGene.txt
+DMPK	Kinase	PfamKinase
+DMPK1	Kinase	Kincat_Hsap.08.02.txt
+DMPK2	Kinase	Kincat_Hsap.08.02.txt
+DMRT1	TranscriptionFactor	addTF_JL.tsv
+DMRT2	TranscriptionFactor	addTF_JL.tsv
+DMRT3	TranscriptionFactor	addTF_JL.tsv
+DMRTA1	TranscriptionFactor	addTF_JL.tsv
+DMRTA2	TranscriptionFactor	addTF_JL.tsv
+DMRTB1	TranscriptionFactor	addTF_JL.tsv
+DMRTC2	TranscriptionFactor	addTF_JL.tsv
+DMTF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+DNAI7	TumorSuppressorGene	TumorSuppressorGene.txt
+DNAJA3	TumorSuppressorGene	TumorSuppressorGene.txt
+DNAJB1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+DNAJB4	TumorSuppressorGene	TumorSuppressorGene.txt
+DNAJC11	TumorSuppressorGene	TumorSuppressorGene.txt
+DNAPK	Kinase	Kincat_Hsap.08.02.txt
+DND1	TumorSuppressorGene	TumorSuppressorGene.txt
+DNM2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DNMT1	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+DNMT3A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+DNMT3B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+DNTTIP1	TranscriptionFactor	addTF_JL.tsv
+DOK1	TumorSuppressorGene	TumorSuppressorGene.txt
+DOK2	TumorSuppressorGene	TumorSuppressorGene.txt
+DOK3	TumorSuppressorGene	TumorSuppressorGene.txt
+DOT1L	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+DPF1	TranscriptionFactor	addTF_JL.tsv
+DPF3	TranscriptionFactor	addTF_JL.tsv
+DPH1	TumorSuppressorGene	TumorSuppressorGene.txt
+DPP4	TumorSuppressorGene	TumorSuppressorGene.txt
+DPRX	TranscriptionFactor	addTF_JL.tsv
+DR1	TranscriptionFactor	addTF_JL.tsv
+DRAK1	Kinase	Kincat_Hsap.08.02.txt
+DRAK2	Kinase	Kincat_Hsap.08.02.txt
+DRAP1	TranscriptionFactor	addTF_JL.tsv
+DRGX	TranscriptionFactor	addTF_JL.tsv
+DROSHA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+DSC2	TumorSuppressorGene	TumorSuppressorGene.txt
+DSC3	TumorSuppressorGene	TumorSuppressorGene.txt
+DSP	TumorSuppressorGene	TumorSuppressorGene.txt
+DSTYK	Kinase	PfamKinase
+DTX1	TumorSuppressorGene	OncoKBv20240704
+DUSP1	TumorSuppressorGene	TumorSuppressorGene.txt
+DUSP22	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+DUSP26	TumorSuppressorGene	TumorSuppressorGene.txt
+DUSP4	TumorSuppressorGene	OncoKBv20240704
+DUSP5	TumorSuppressorGene	TumorSuppressorGene.txt
+DUSP6	TumorSuppressorGene	TumorSuppressorGene.txt
+DUSP9	TumorSuppressorGene	TumorSuppressorGene.txt
+DUX1	TranscriptionFactor	addTF_JL.tsv
+DUX3	TranscriptionFactor	addTF_JL.tsv
+DUX4	TranscriptionFactor	addTF_JL.tsv
+DUX4L1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+DUXA	TranscriptionFactor	addTF_JL.tsv
+DYRK1A	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DYRK1B	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DYRK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DYRK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DYRK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+DZIP1	TranscriptionFactor	addTF_JL.tsv
+Dec-01	TumorSuppressorGene	TumorSuppressorGene.txt
+E2F1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+E2F2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+E2F3	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+E2F4	TranscriptionFactor	addTF_JL.tsv
+E2F5	TranscriptionFactor	addTF_JL.tsv
+E2F6	TranscriptionFactor	addTF_JL.tsv
+E2F7	TranscriptionFactor	addTF_JL.tsv
+E2F8	TranscriptionFactor	addTF_JL.tsv
+E4F1	TranscriptionFactor	addTF_JL.tsv
+EAF1	TumorSuppressorGene	TumorSuppressorGene.txt
+EAF2	TumorSuppressorGene	TumorSuppressorGene.txt
+EBF1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+EBF2	TranscriptionFactor	addTF_JL.tsv
+EBF3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+EBF4	TranscriptionFactor	addTF_JL.tsv
+ECRG4	TumorSuppressorGene	TumorSuppressorGene.txt
+ECSIT	Oncogene	OncoKBv20240704
+ECT2	TumorSuppressorGene	TumorSuppressorGene.txt
+ECT2L	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+EDA2R	TumorSuppressorGene	TumorSuppressorGene.txt
+EDNRB	TumorSuppressorGene	TumorSuppressorGene.txt
+EEA1	TranscriptionFactor	addTF_JL.tsv
+EED	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+EEF1A1	TumorSuppressorGene	TumorSuppressorGene.txt
+EEF1E1	TumorSuppressorGene	TumorSuppressorGene.txt
+EEF2K	Kinase	PfamKinase
+EFNA5	TumorSuppressorGene	TumorSuppressorGene.txt
+EGFL7	Oncogene	OncoKBv20240704
+EGFR	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+EGLN1	TumorSuppressorGene	TumorSuppressorGene.txt
+EGLN3	TumorSuppressorGene	TumorSuppressorGene.txt
+EGR1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+EGR2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+EGR3	TranscriptionFactor	addTF_JL.tsv
+EGR4	TranscriptionFactor	addTF_JL.tsv
+EHD3	TumorSuppressorGene	TumorSuppressorGene.txt
+EHF	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+EI24	TumorSuppressorGene	TumorSuppressorGene.txt
+EIF1AX	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+EIF2AK1	Kinase	PfamKinase
+EIF2AK2	Kinase	PfamKinase
+EIF2AK3	Kinase	PfamKinase
+EIF2AK4	Kinase	PfamKinase
+EIF2B1	TumorSuppressorGene	OncoKBv20240704
+EIF3E	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+EIF3F	TumorSuppressorGene	TumorSuppressorGene.txt
+EIF4A2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+EIF4E	Oncogene	OncoKBv20240704
+ELF1	TranscriptionFactor	addTF_JL.tsv
+ELF2	TranscriptionFactor	addTF_JL.tsv
+ELF3	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ELF4	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ELF5	TranscriptionFactor	addTF_JL.tsv
+ELK1	TranscriptionFactor	addTF_JL.tsv
+ELK3	TranscriptionFactor	addTF_JL.tsv
+ELK4	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ELL	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ELN	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ELOA	TumorSuppressorGene	TumorSuppressorGene.txt
+EML4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+EMP1	TumorSuppressorGene	TumorSuppressorGene.txt
+EMP2	TumorSuppressorGene	TumorSuppressorGene.txt
+EMSY	Oncogene	OncoKBv20240704
+EMX1	TranscriptionFactor	addTF_JL.tsv
+EMX2	TranscriptionFactor	addTF_JL.tsv
+EN1	TranscriptionFactor	addTF_JL.tsv
+EN2	TranscriptionFactor	addTF_JL.tsv
+EOMES	TranscriptionFactor	addTF_JL.tsv
+EP300	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+EP400	TumorSuppressorGene	OncoKBv20240704
+EPAS1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+EPB41	TumorSuppressorGene	TumorSuppressorGene.txt
+EPB41L3	TumorSuppressorGene	TumorSuppressorGene.txt
+EPCAM	TumorSuppressorGene	OncoKBv20240704
+EPHA1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+EPHA10	Kinase	PfamKinase
+EPHA2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+EPHA3	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+EPHA4	Kinase	PfamKinase
+EPHA5	Kinase	PfamKinase
+EPHA6	Kinase	PfamKinase
+EPHA7	CosmicCensus, Kinase, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+EPHA8	Kinase	PfamKinase
+EPHB1	Kinase, Oncogene, TumorSuppressorGene	PfamKinase, OncoKBv20240704
+EPHB2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+EPHB3	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+EPHB4	TumorSuppressorGene, Kinase, Oncogene	TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704
+EPHB6	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+EPOR	Oncogene	OncoKBv20240704
+EPS15	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ERBB2	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ERBB3	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ERBB4	TumorSuppressorGene, CosmicCensus, Kinase, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+ERC1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ERCC1	TumorSuppressorGene	OncoKBv20240704
+ERCC2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ERCC3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ERCC4	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ERCC5	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ERF	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+ERG	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ERN1	Kinase	PfamKinase
+ERRFI1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+ESCO2	TumorSuppressorGene	OncoKBv20240704
+ESR1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ESR2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ESRP1	TumorSuppressorGene	TumorSuppressorGene.txt
+ESRRA	TranscriptionFactor	addTF_JL.tsv
+ESRRB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ESRRG	TranscriptionFactor	addTF_JL.tsv
+ESX1	TranscriptionFactor	addTF_JL.tsv
+ETAA1	TumorSuppressorGene	OncoKBv20240704
+ETF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ETNK1	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+ETNK2	Kinase	PfamKinase
+ETS1	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+ETS2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ETV1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ETV2	TranscriptionFactor	addTF_JL.tsv
+ETV3	TranscriptionFactor	addTF_JL.tsv
+ETV3L	TranscriptionFactor	addTF_JL.tsv
+ETV4	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ETV5	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ETV6	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ETV7	TranscriptionFactor	addTF_JL.tsv
+EVX1	TranscriptionFactor	addTF_JL.tsv
+EVX2	TranscriptionFactor	addTF_JL.tsv
+EWSR1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+EXT1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+EXT2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+EXTL1	TumorSuppressorGene	TumorSuppressorGene.txt
+EXTL2	TumorSuppressorGene	TumorSuppressorGene.txt
+EXTL3	TumorSuppressorGene	TumorSuppressorGene.txt
+EYA4	TumorSuppressorGene	TumorSuppressorGene.txt
+EZH1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+EZH2	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+EZHIP	Oncogene	OncoKBv20240704
+EZR	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+EphA1	Kinase	Kincat_Hsap.08.02.txt
+EphA10	Kinase	Kincat_Hsap.08.02.txt
+EphA2	Kinase	Kincat_Hsap.08.02.txt
+EphA3	Kinase	Kincat_Hsap.08.02.txt
+EphA4	Kinase	Kincat_Hsap.08.02.txt
+EphA5	Kinase	Kincat_Hsap.08.02.txt
+EphA6	Kinase	Kincat_Hsap.08.02.txt
+EphA7	Kinase	Kincat_Hsap.08.02.txt
+EphA8	Kinase	Kincat_Hsap.08.02.txt
+EphB1	Kinase	Kincat_Hsap.08.02.txt
+EphB2	Kinase	Kincat_Hsap.08.02.txt
+EphB3	Kinase	Kincat_Hsap.08.02.txt
+EphB4	Kinase	Kincat_Hsap.08.02.txt
+EphB6	Kinase	Kincat_Hsap.08.02.txt
+ErbB2	Kinase	Kincat_Hsap.08.02.txt
+ErbB3	Kinase	Kincat_Hsap.08.02.txt
+ErbB4	Kinase	Kincat_Hsap.08.02.txt
+Erk1	Kinase	Kincat_Hsap.08.02.txt
+Erk2	Kinase	Kincat_Hsap.08.02.txt
+Erk3	Kinase	Kincat_Hsap.08.02.txt
+Erk3ps1	Kinase	Kincat_Hsap.08.02.txt
+Erk3ps2	Kinase	Kincat_Hsap.08.02.txt
+Erk3ps3	Kinase	Kincat_Hsap.08.02.txt
+Erk3ps4	Kinase	Kincat_Hsap.08.02.txt
+Erk4	Kinase	Kincat_Hsap.08.02.txt
+Erk5	Kinase	Kincat_Hsap.08.02.txt
+Erk7	Kinase	Kincat_Hsap.08.02.txt
+FABP3	TumorSuppressorGene	TumorSuppressorGene.txt
+FADD	TumorSuppressorGene	TumorSuppressorGene.txt
+FAK	Kinase	Kincat_Hsap.08.02.txt
+FAM131B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FAM135B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FAM170A	TranscriptionFactor	addTF_JL.tsv
+FAM172A	TumorSuppressorGene	TumorSuppressorGene.txt
+FAM188A	TumorSuppressorGene	TumorSuppressorGene.txt
+FAM200B	TranscriptionFactor	addTF_JL.tsv
+FAM47C	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FANCA	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FANCC	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FANCD2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FANCE	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FANCF	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FANCG	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FANCL	TumorSuppressorGene	OncoKBv20240704
+FANCM	TumorSuppressorGene	OncoKBv20240704
+FAS	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FASTK	Kinase	Kincat_Hsap.08.02.txt
+FAT1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FAT3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FAT4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+FBLN1	TumorSuppressorGene	TumorSuppressorGene.txt
+FBLN2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FBP1	TumorSuppressorGene	TumorSuppressorGene.txt
+FBXL13	TumorSuppressorGene	TumorSuppressorGene.txt
+FBXL19	TranscriptionFactor	addTF_JL.tsv
+FBXO11	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FBXO25	TumorSuppressorGene	TumorSuppressorGene.txt
+FBXO31	TumorSuppressorGene	TumorSuppressorGene.txt
+FBXO32	TumorSuppressorGene	TumorSuppressorGene.txt
+FBXW7	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FCGR2B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FCRL4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FCSK	Kinase	PfamKinase
+FEN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FER	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+FER1L4	TumorSuppressorGene	TumorSuppressorGene.txt
+FERD3L	TranscriptionFactor	addTF_JL.tsv
+FERps	Kinase	Kincat_Hsap.08.02.txt
+FES	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+FEV	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+FEZF1	TranscriptionFactor	addTF_JL.tsv
+FEZF2	TranscriptionFactor	addTF_JL.tsv
+FGF1	Oncogene	OncoKBv20240704
+FGF10	Oncogene	OncoKBv20240704
+FGF14	TumorSuppressorGene	OncoKBv20240704
+FGF19	Oncogene	OncoKBv20240704
+FGF2	Oncogene	OncoKBv20240704
+FGF23	Oncogene	OncoKBv20240704
+FGF3	Oncogene	OncoKBv20240704
+FGF4	Oncogene	OncoKBv20240704
+FGF5	Oncogene	OncoKBv20240704
+FGF6	Oncogene	OncoKBv20240704
+FGF7	Oncogene	OncoKBv20240704
+FGF8	Oncogene	OncoKBv20240704
+FGF9	Oncogene	OncoKBv20240704
+FGFR1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+FGFR1OP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FGFR2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+FGFR3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+FGFR4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+FGR	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+FH	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FHIT	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FHL1	TumorSuppressorGene	TumorSuppressorGene.txt
+FIGLA	TranscriptionFactor	addTF_JL.tsv
+FIP1L1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FIZ1	TranscriptionFactor	addTF_JL.tsv
+FKBP9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FLCN	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FLI1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+FLNA	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+FLT1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+FLT1ps	Kinase	Kincat_Hsap.08.02.txt
+FLT3	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+FLT4	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+FLYWCH1	TranscriptionFactor	addTF_JL.tsv
+FMS	Kinase	Kincat_Hsap.08.02.txt
+FNBP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FOLH1	Oncogene	OncoKBv20240704
+FOLR1	Oncogene	OncoKBv20240704
+FOS	TranscriptionFactor	addTF_JL.tsv
+FOSB	TranscriptionFactor	addTF_JL.tsv
+FOSL1	TranscriptionFactor	addTF_JL.tsv
+FOSL2	TranscriptionFactor	addTF_JL.tsv
+FOXA1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+FOXA2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+FOXA3	TranscriptionFactor	addTF_JL.tsv
+FOXB1	TranscriptionFactor	addTF_JL.tsv
+FOXB2	TranscriptionFactor	addTF_JL.tsv
+FOXC1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+FOXC2	TranscriptionFactor	addTF_JL.tsv
+FOXD1	TranscriptionFactor	addTF_JL.tsv
+FOXD2	TranscriptionFactor	addTF_JL.tsv
+FOXD3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+FOXD4	TranscriptionFactor	addTF_JL.tsv
+FOXD4L1	TranscriptionFactor	addTF_JL.tsv
+FOXD4L3	TranscriptionFactor	addTF_JL.tsv
+FOXD4L4	TranscriptionFactor	addTF_JL.tsv
+FOXD4L5	TranscriptionFactor	addTF_JL.tsv
+FOXD4L6	TranscriptionFactor	addTF_JL.tsv
+FOXE1	TranscriptionFactor	addTF_JL.tsv
+FOXE3	TranscriptionFactor	addTF_JL.tsv
+FOXF1	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+FOXF2	TranscriptionFactor	addTF_JL.tsv
+FOXG1	TranscriptionFactor	addTF_JL.tsv
+FOXH1	TranscriptionFactor	addTF_JL.tsv
+FOXI1	TranscriptionFactor	addTF_JL.tsv
+FOXI2	TranscriptionFactor	addTF_JL.tsv
+FOXI3	TranscriptionFactor	addTF_JL.tsv
+FOXJ1	TranscriptionFactor	addTF_JL.tsv
+FOXJ2	TranscriptionFactor	addTF_JL.tsv
+FOXJ3	TranscriptionFactor	addTF_JL.tsv
+FOXK1	TranscriptionFactor	addTF_JL.tsv
+FOXK2	TranscriptionFactor	addTF_JL.tsv
+FOXL1	TranscriptionFactor	addTF_JL.tsv
+FOXL2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+FOXM1	TranscriptionFactor	addTF_JL.tsv
+FOXN1	TranscriptionFactor	addTF_JL.tsv
+FOXN2	TranscriptionFactor	addTF_JL.tsv
+FOXN3	TranscriptionFactor	addTF_JL.tsv
+FOXN4	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+FOXO1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+FOXO3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+FOXO4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+FOXO6	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+FOXP1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+FOXP2	TranscriptionFactor	addTF_JL.tsv
+FOXP3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+FOXP4	TranscriptionFactor	addTF_JL.tsv
+FOXQ1	TranscriptionFactor	addTF_JL.tsv
+FOXR1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+FOXR2	TranscriptionFactor	addTF_JL.tsv, AddedallOnco_Feb2017.tsv
+FOXS1	TranscriptionFactor	addTF_JL.tsv
+FPGT-TNNI3K	Kinase	PfamKinase
+FRAP	Kinase	Kincat_Hsap.08.02.txt
+FRK	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+FRS2	Oncogene	OncoKBv20240704
+FRS3	TumorSuppressorGene	TumorSuppressorGene.txt
+FSTL1	Oncogene	OncoKBv20240704
+FSTL3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+FUBP1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FURIN	Oncogene	OncoKBv20240704
+FUS	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+FXN	TumorSuppressorGene	TumorSuppressorGene.txt
+FYN	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+FZR1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+Fused	Kinase	Kincat_Hsap.08.02.txt
+G0S2	TumorSuppressorGene	TumorSuppressorGene.txt
+G11	Kinase	Kincat_Hsap.08.02.txt
+GAB1	Oncogene	OncoKBv20240704
+GAB2	Oncogene	OncoKBv20240704
+GABARAP	TumorSuppressorGene	TumorSuppressorGene.txt
+GABPA	TranscriptionFactor	addTF_JL.tsv
+GABRA6	Oncogene	OncoKBv20240704
+GADD45A	TumorSuppressorGene	TumorSuppressorGene.txt
+GADD45B	TumorSuppressorGene	TumorSuppressorGene.txt
+GADD45G	TumorSuppressorGene	TumorSuppressorGene.txt
+GADD45GIP1	TumorSuppressorGene	TumorSuppressorGene.txt
+GAK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+GALK1	Kinase	PfamKinase
+GALK2	Kinase	PfamKinase
+GALR1	TumorSuppressorGene	TumorSuppressorGene.txt
+GANAB	TumorSuppressorGene	TumorSuppressorGene.txt
+GAS1	TumorSuppressorGene	TumorSuppressorGene.txt
+GAS5	TumorSuppressorGene	TumorSuppressorGene.txt
+GAS7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+GATA1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+GATA2	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+GATA3	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+GATA4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+GATA5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+GATA6	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+GATAD2A	TranscriptionFactor	addTF_JL.tsv
+GATAD2B	TranscriptionFactor	addTF_JL.tsv
+GBP1	TumorSuppressorGene	TumorSuppressorGene.txt
+GBX1	TranscriptionFactor	addTF_JL.tsv
+GBX2	TranscriptionFactor	addTF_JL.tsv
+GCK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+GCM1	TranscriptionFactor	addTF_JL.tsv
+GCM2	TranscriptionFactor	addTF_JL.tsv
+GCN2	Kinase	Kincat_Hsap.08.02.txt
+GFI1	TranscriptionFactor	addTF_JL.tsv
+GFI1B	TranscriptionFactor	addTF_JL.tsv
+GGNBP2	TumorSuppressorGene	TumorSuppressorGene.txt
+GJA1	TumorSuppressorGene	TumorSuppressorGene.txt
+GJB2	TumorSuppressorGene	TumorSuppressorGene.txt
+GKN1	TumorSuppressorGene	TumorSuppressorGene.txt
+GKN2	TumorSuppressorGene	TumorSuppressorGene.txt
+GLI1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+GLI2	TranscriptionFactor	addTF_JL.tsv
+GLI3	TranscriptionFactor	addTF_JL.tsv
+GLI4	TranscriptionFactor	addTF_JL.tsv
+GLIPR1	TumorSuppressorGene	TumorSuppressorGene.txt
+GLIS1	TranscriptionFactor	addTF_JL.tsv
+GLIS2	TranscriptionFactor	addTF_JL.tsv
+GLIS3	TranscriptionFactor	addTF_JL.tsv
+GLMP	TranscriptionFactor	addTF_JL.tsv
+GLS2	TumorSuppressorGene	TumorSuppressorGene.txt
+GLTSCR1	TumorSuppressorGene	TumorSuppressorGene.txt
+GLTSCR2	TumorSuppressorGene	TumorSuppressorGene.txt
+GLYR1	TranscriptionFactor	addTF_JL.tsv
+GMEB1	TranscriptionFactor	addTF_JL.tsv
+GMEB2	TranscriptionFactor	addTF_JL.tsv
+GMPS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+GNA11	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+GNA12	Oncogene	OncoKBv20240704
+GNA13	Oncogene, TumorSuppressorGene	OncoKBv20240704
+GNAQ	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+GNAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+GNAT1	TumorSuppressorGene	TumorSuppressorGene.txt
+GNB1	Oncogene	OncoKBv20240704
+GNB2L1	TumorSuppressorGene	TumorSuppressorGene.txt
+GNMT	TumorSuppressorGene	TumorSuppressorGene.txt
+GOLGA5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+GOPC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+GORAB	TumorSuppressorGene	TumorSuppressorGene.txt
+GPBP1	TranscriptionFactor	addTF_JL.tsv
+GPBP1L1	TranscriptionFactor	addTF_JL.tsv
+GPC3	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+GPC5	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+GPHN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+GPRC5A	TumorSuppressorGene	TumorSuppressorGene.txt
+GPRK4	Kinase	Kincat_Hsap.08.02.txt
+GPRK5	Kinase	Kincat_Hsap.08.02.txt
+GPRK6	Kinase	Kincat_Hsap.08.02.txt
+GPRK6ps	Kinase	Kincat_Hsap.08.02.txt
+GPRK7	Kinase	Kincat_Hsap.08.02.txt
+GPS2	TumorSuppressorGene	OncoKBv20240704
+GPX3	TumorSuppressorGene	TumorSuppressorGene.txt
+GRB7	Oncogene	OncoKBv20240704
+GREM1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+GRHL1	TranscriptionFactor	addTF_JL.tsv
+GRHL2	TranscriptionFactor	addTF_JL.tsv
+GRHL3	TranscriptionFactor	addTF_JL.tsv
+GRIN2A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+GRK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+GRK2	Kinase	PfamKinase
+GRK3	Kinase	PfamKinase
+GRK4	Kinase	PfamKinase
+GRK5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+GRK6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+GRK7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+GRM3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+GSC	TranscriptionFactor	addTF_JL.tsv
+GSC2	TranscriptionFactor	addTF_JL.tsv
+GSDME	TumorSuppressorGene	TumorSuppressorGene.txt
+GSK3A	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+GSK3B	Kinase, TumorSuppressorGene, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase, OncoKBv20240704
+GSN	TumorSuppressorGene	TumorSuppressorGene.txt
+GSTP1	TumorSuppressorGene	TumorSuppressorGene.txt
+GSTT1	TumorSuppressorGene	TumorSuppressorGene.txt
+GSX1	TranscriptionFactor	addTF_JL.tsv
+GSX2	TranscriptionFactor	addTF_JL.tsv
+GTF2B	TranscriptionFactor	addTF_JL.tsv
+GTF2I	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+GTF2IRD1	TranscriptionFactor	addTF_JL.tsv
+GTF2IRD2	TranscriptionFactor	addTF_JL.tsv
+GTF2IRD2B	TranscriptionFactor	addTF_JL.tsv
+GTF3A	TranscriptionFactor	addTF_JL.tsv
+GTPBP4	TumorSuppressorGene	TumorSuppressorGene.txt
+GUCY2C	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+GUCY2D	Kinase	PfamKinase
+GUCY2F	Kinase	PfamKinase
+GZF1	TranscriptionFactor	addTF_JL.tsv
+H1-3	TumorSuppressorGene	OncoKBv20240704
+H1-4	Oncogene	OncoKBv20240704
+H1-5	TumorSuppressorGene	OncoKBv20240704
+H11	Kinase	Kincat_Hsap.08.02.txt
+H19	TumorSuppressorGene	TumorSuppressorGene.txt
+H2AC17	Oncogene	OncoKBv20240704
+H2AFX	TumorSuppressorGene	TumorSuppressorGene.txt
+H2AX	TumorSuppressorGene	TumorSuppressorGene.txt
+H3-3A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+H3-3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+H3C2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+H3F3A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+H3F3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+H4C9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HACD4	TumorSuppressorGene	TumorSuppressorGene.txt
+HACE1	TumorSuppressorGene	TumorSuppressorGene.txt
+HAND1	TranscriptionFactor	addTF_JL.tsv
+HAND2	TranscriptionFactor	addTF_JL.tsv
+HBP1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+HCAR2	TumorSuppressorGene	TumorSuppressorGene.txt
+HCK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+HDAC1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+HDAC2	Oncogene	OncoKBv20240704
+HDAC3	TumorSuppressorGene	TumorSuppressorGene.txt
+HDAC4	Oncogene, TumorSuppressorGene	OncoKBv20240704
+HDAC7	Oncogene	OncoKBv20240704
+HDX	TranscriptionFactor	addTF_JL.tsv
+HECA	TumorSuppressorGene	TumorSuppressorGene.txt
+HELT	TranscriptionFactor	addTF_JL.tsv
+HEPACAM	TumorSuppressorGene	TumorSuppressorGene.txt
+HERPUD1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HES1	TranscriptionFactor	addTF_JL.tsv
+HES2	TranscriptionFactor	addTF_JL.tsv
+HES3	TranscriptionFactor	addTF_JL.tsv
+HES4	TranscriptionFactor	addTF_JL.tsv
+HES5	TranscriptionFactor	addTF_JL.tsv
+HES6	TranscriptionFactor	addTF_JL.tsv
+HES7	TranscriptionFactor	addTF_JL.tsv
+HESX1	TranscriptionFactor	addTF_JL.tsv
+HEY1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HEY2	TranscriptionFactor	addTF_JL.tsv
+HEYL	TranscriptionFactor	addTF_JL.tsv
+HFE	Oncogene	OncoKBv20240704
+HGF	Oncogene	OncoKBv20240704
+HGK	Kinase	Kincat_Hsap.08.02.txt
+HH498	Kinase	Kincat_Hsap.08.02.txt
+HHEX	TranscriptionFactor	addTF_JL.tsv
+HIC1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+HIC2	TranscriptionFactor	addTF_JL.tsv
+HIF1A	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+HIF3A	TranscriptionFactor	addTF_JL.tsv
+HINFP	TranscriptionFactor	addTF_JL.tsv
+HINT1	TumorSuppressorGene	TumorSuppressorGene.txt
+HIP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HIPK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+HIPK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+HIPK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+HIPK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+HIRA	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+HIST1H3B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HIST1H4I	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HIVEP1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+HIVEP2	TranscriptionFactor	addTF_JL.tsv
+HIVEP3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+HK1	Kinase	PfamKinase
+HK2	Kinase	PfamKinase
+HK3	Kinase	PfamKinase
+HKDC1	Kinase	PfamKinase
+HKR1	TranscriptionFactor	addTF_JL.tsv
+HLA-A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+HLA-B	TumorSuppressorGene	OncoKBv20240704
+HLA-C	TumorSuppressorGene	OncoKBv20240704
+HLF	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HLTF	TumorSuppressorGene	TumorSuppressorGene.txt
+HLX	TranscriptionFactor	addTF_JL.tsv
+HMBOX1	TranscriptionFactor	addTF_JL.tsv
+HMG20A	TranscriptionFactor	addTF_JL.tsv
+HMG20B	TranscriptionFactor	addTF_JL.tsv
+HMGA1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+HMGA2	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+HMGN2P46	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HMGN3	TranscriptionFactor	addTF_JL.tsv
+HMX1	TranscriptionFactor	addTF_JL.tsv
+HMX2	TranscriptionFactor	addTF_JL.tsv
+HMX3	TranscriptionFactor	addTF_JL.tsv
+HNF1A	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+HNF1B	TranscriptionFactor	addTF_JL.tsv
+HNF4A	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+HNF4G	TranscriptionFactor	addTF_JL.tsv
+HNRNPA2B1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HOMER2	TumorSuppressorGene	TumorSuppressorGene.txt
+HOMEZ	TranscriptionFactor	addTF_JL.tsv
+HOOK3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HOPX	TumorSuppressorGene	TumorSuppressorGene.txt
+HOTS	TumorSuppressorGene	TumorSuppressorGene.txt
+HOXA1	TranscriptionFactor	addTF_JL.tsv
+HOXA10	TranscriptionFactor	addTF_JL.tsv
+HOXA11	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+HOXA13	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HOXA2	TranscriptionFactor	addTF_JL.tsv
+HOXA3	TranscriptionFactor	addTF_JL.tsv
+HOXA4	TranscriptionFactor	addTF_JL.tsv
+HOXA5	TranscriptionFactor	addTF_JL.tsv
+HOXA6	TranscriptionFactor	addTF_JL.tsv
+HOXA7	TranscriptionFactor	addTF_JL.tsv
+HOXA9	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HOXB1	TranscriptionFactor	addTF_JL.tsv
+HOXB13	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+HOXB2	TranscriptionFactor	addTF_JL.tsv
+HOXB3	TranscriptionFactor	addTF_JL.tsv
+HOXB4	TranscriptionFactor	addTF_JL.tsv
+HOXB5	TranscriptionFactor	addTF_JL.tsv
+HOXB6	TranscriptionFactor	addTF_JL.tsv
+HOXB7	TranscriptionFactor	addTF_JL.tsv
+HOXB8	TranscriptionFactor	addTF_JL.tsv
+HOXB9	TranscriptionFactor	addTF_JL.tsv
+HOXC10	TranscriptionFactor	addTF_JL.tsv
+HOXC11	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HOXC12	TranscriptionFactor	addTF_JL.tsv
+HOXC13	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HOXC4	TranscriptionFactor	addTF_JL.tsv
+HOXC5	TranscriptionFactor	addTF_JL.tsv
+HOXC6	TranscriptionFactor	addTF_JL.tsv
+HOXC8	TranscriptionFactor	addTF_JL.tsv
+HOXC9	TranscriptionFactor	addTF_JL.tsv
+HOXD1	TranscriptionFactor	addTF_JL.tsv
+HOXD10	TranscriptionFactor	addTF_JL.tsv
+HOXD11	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HOXD12	TranscriptionFactor	addTF_JL.tsv
+HOXD13	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+HOXD3	TranscriptionFactor	addTF_JL.tsv
+HOXD4	TranscriptionFactor	addTF_JL.tsv
+HOXD8	TranscriptionFactor	addTF_JL.tsv
+HOXD9	TranscriptionFactor	addTF_JL.tsv
+HPGD	TumorSuppressorGene	TumorSuppressorGene.txt
+HPK1	Kinase	Kincat_Hsap.08.02.txt
+HRAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+HRASLS2	TumorSuppressorGene	TumorSuppressorGene.txt
+HRG	TumorSuppressorGene	TumorSuppressorGene.txt
+HRI	Kinase	Kincat_Hsap.08.02.txt
+HRIps	Kinase	Kincat_Hsap.08.02.txt
+HSD17B2	TumorSuppressorGene	OncoKBv20240704
+HSD3B1	Oncogene	OncoKBv20240704
+HSER	Kinase	Kincat_Hsap.08.02.txt
+HSF1	TranscriptionFactor	addTF_JL.tsv
+HSF2	TranscriptionFactor	addTF_JL.tsv
+HSF4	TranscriptionFactor	addTF_JL.tsv
+HSF5	TranscriptionFactor	addTF_JL.tsv
+HSFX1	TranscriptionFactor	addTF_JL.tsv
+HSFX2	TranscriptionFactor	addTF_JL.tsv
+HSFY1	TranscriptionFactor	addTF_JL.tsv
+HSFY2	TranscriptionFactor	addTF_JL.tsv
+HSP90AA1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+HSP90AB1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+HSP90B1	TumorSuppressorGene	TumorSuppressorGene.txt
+HSPB7	TumorSuppressorGene	TumorSuppressorGene.txt
+HSPD1	TumorSuppressorGene	TumorSuppressorGene.txt
+HTATIP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+HTRA1	TumorSuppressorGene	TumorSuppressorGene.txt
+HTRA2	TumorSuppressorGene	TumorSuppressorGene.txt
+HTRA3	TumorSuppressorGene	TumorSuppressorGene.txt
+HUNK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+Haspin	Kinase	Kincat_Hsap.08.02.txt
+ICK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+ICOSLG	Oncogene	OncoKBv20240704
+ID1	Oncogene	OncoKBv20240704
+ID3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ID4	TumorSuppressorGene	TumorSuppressorGene.txt
+IDH1	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+IDH2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+IER3	TumorSuppressorGene	TumorSuppressorGene.txt
+IFI16	TumorSuppressorGene	TumorSuppressorGene.txt
+IFNGR1	TumorSuppressorGene	OncoKBv20240704
+IFT88	TumorSuppressorGene	TumorSuppressorGene.txt
+IGF1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+IGF1R	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+IGF2	Oncogene	OncoKBv20240704
+IGF2BP2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+IGF2R	TumorSuppressorGene	TumorSuppressorGene.txt
+IGFALS	TumorSuppressorGene	TumorSuppressorGene.txt
+IGFBP3	TumorSuppressorGene	TumorSuppressorGene.txt
+IGFBP4	TumorSuppressorGene	TumorSuppressorGene.txt
+IGFBP5	TumorSuppressorGene	TumorSuppressorGene.txt
+IGFBP7	TumorSuppressorGene	TumorSuppressorGene.txt
+IGFBPL1	TumorSuppressorGene	TumorSuppressorGene.txt
+IGH	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addedToallOnco_Feb2017.tsv
+IGH-@	Oncogene	addedToallOnco_Feb2017.tsv
+IGH@	Oncogene	addedToallOnco_Feb2017.tsv
+IGK	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+IGL	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addedToallOnco_Feb2017.tsv
+IGL-@	Oncogene	addedToallOnco_Feb2017.tsv
+IGL@	Oncogene	addedToallOnco_Feb2017.tsv
+IKBKB	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+IKBKE	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+IKKa	Kinase	Kincat_Hsap.08.02.txt
+IKKb	Kinase	Kincat_Hsap.08.02.txt
+IKKe	Kinase	Kincat_Hsap.08.02.txt
+IKZF1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+IKZF2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+IKZF3	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+IKZF4	TranscriptionFactor	addTF_JL.tsv
+IKZF5	TranscriptionFactor	addTF_JL.tsv
+IL17A	TumorSuppressorGene	TumorSuppressorGene.txt
+IL17RD	TumorSuppressorGene	TumorSuppressorGene.txt
+IL2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+IL21R	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+IL24	TumorSuppressorGene	TumorSuppressorGene.txt
+IL3	Oncogene	OncoKBv20240704
+IL6ST	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+IL7R	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ILK	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+ING1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+ING2	TumorSuppressorGene	TumorSuppressorGene.txt
+ING3	TumorSuppressorGene	TumorSuppressorGene.txt
+ING4	TumorSuppressorGene	TumorSuppressorGene.txt
+ING5	TumorSuppressorGene	TumorSuppressorGene.txt
+INGX	TumorSuppressorGene	TumorSuppressorGene.txt
+INHA	TumorSuppressorGene	OncoKBv20240704
+INHBA	Oncogene, TumorSuppressorGene	OncoKBv20240704
+INPP4B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+INPPL1	TumorSuppressorGene	OncoKBv20240704
+INSM1	TranscriptionFactor	addTF_JL.tsv
+INSM2	TranscriptionFactor	addTF_JL.tsv
+INSR	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+INSRR	Kinase	PfamKinase
+INTS6	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+IQGAP1	Oncogene	OncoKBv20240704
+IQGAP2	TumorSuppressorGene	TumorSuppressorGene.txt
+IRAG1	TumorSuppressorGene	TumorSuppressorGene.txt
+IRAG2	TumorSuppressorGene	TumorSuppressorGene.txt
+IRAK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+IRAK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+IRAK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+IRAK4	Kinase	Kincat_Hsap.08.02.txt
+IRE1	Kinase	Kincat_Hsap.08.02.txt
+IRE2	Kinase	Kincat_Hsap.08.02.txt
+IRF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+IRF2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+IRF3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+IRF4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+IRF5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+IRF6	TranscriptionFactor	addTF_JL.tsv
+IRF7	TranscriptionFactor	addTF_JL.tsv
+IRF8	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+IRF9	TranscriptionFactor	addTF_JL.tsv
+IRR	Kinase	Kincat_Hsap.08.02.txt
+IRS1	Oncogene	OncoKBv20240704
+IRS2	Oncogene	OncoKBv20240704
+IRS4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+IRX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+IRX2	TranscriptionFactor	addTF_JL.tsv
+IRX3	TranscriptionFactor	addTF_JL.tsv
+IRX4	TranscriptionFactor	addTF_JL.tsv
+IRX5	TranscriptionFactor	addTF_JL.tsv
+IRX6	TranscriptionFactor	addTF_JL.tsv
+ISG15	TumorSuppressorGene	TumorSuppressorGene.txt
+ISL1	TranscriptionFactor	addTF_JL.tsv
+ISL2	TranscriptionFactor	addTF_JL.tsv
+ISX	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ITGA5	TumorSuppressorGene	TumorSuppressorGene.txt
+ITGA7	TumorSuppressorGene	TumorSuppressorGene.txt
+ITGAV	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+ITGB1	TumorSuppressorGene	TumorSuppressorGene.txt
+ITGB3	TumorSuppressorGene	TumorSuppressorGene.txt
+ITK	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+ITPKB	Oncogene	OncoKBv20240704
+JAK1	Kinase, CosmicCensus, Oncogene, TumorSuppressorGene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+JAK2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+JAK3	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+JARID2	Oncogene, TumorSuppressorGene	OncoKBv20240704
+JAZF1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+JDP2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+JNK1	Kinase	Kincat_Hsap.08.02.txt
+JNK2	Kinase	Kincat_Hsap.08.02.txt
+JNK3	Kinase	Kincat_Hsap.08.02.txt
+JRK	TranscriptionFactor	addTF_JL.tsv
+JRKL	TranscriptionFactor	addTF_JL.tsv
+JUN	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+JUNB	TranscriptionFactor	addTF_JL.tsv
+JUND	TranscriptionFactor	addTF_JL.tsv
+JUP	TumorSuppressorGene	TumorSuppressorGene.txt
+KALRN	Kinase	PfamKinase
+KANK1	TumorSuppressorGene	TumorSuppressorGene.txt
+KAT5	TumorSuppressorGene	TumorSuppressorGene.txt
+KAT6A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KAT6B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KAT7	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+KCMF1	TranscriptionFactor	addTF_JL.tsv
+KCNIP3	TranscriptionFactor	addTF_JL.tsv
+KCNJ5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KCNRG	TumorSuppressorGene	TumorSuppressorGene.txt
+KDM2A	TranscriptionFactor	addTF_JL.tsv
+KDM2B	TranscriptionFactor	addTF_JL.tsv
+KDM3A	TumorSuppressorGene	TumorSuppressorGene.txt
+KDM3B	TumorSuppressorGene	TumorSuppressorGene.txt
+KDM5A	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+KDM5B	TranscriptionFactor	addTF_JL.tsv
+KDM5C	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+KDM5D	Oncogene, TumorSuppressorGene	OncoKBv20240704
+KDM6A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+KDM8	TumorSuppressorGene	TumorSuppressorGene.txt
+KDR	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+KDSR	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KEAP1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+KEL	Oncogene	OncoKBv20240704
+KHS1	Kinase	Kincat_Hsap.08.02.txt
+KHS2	Kinase	Kincat_Hsap.08.02.txt
+KIAA1549	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KIF1B	TumorSuppressorGene	TumorSuppressorGene.txt
+KIF5B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KIF7	TumorSuppressorGene	TumorSuppressorGene.txt
+KIN	TranscriptionFactor	addTF_JL.tsv
+KIS	Kinase	Kincat_Hsap.08.02.txt
+KISS1	TumorSuppressorGene	TumorSuppressorGene.txt
+KIT	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+KL	TumorSuppressorGene	TumorSuppressorGene.txt
+KLF1	TranscriptionFactor	addTF_JL.tsv
+KLF10	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+KLF11	TranscriptionFactor	addTF_JL.tsv
+KLF12	TranscriptionFactor	addTF_JL.tsv
+KLF13	TranscriptionFactor	addTF_JL.tsv
+KLF14	TranscriptionFactor	addTF_JL.tsv
+KLF15	TranscriptionFactor	addTF_JL.tsv
+KLF16	TranscriptionFactor	addTF_JL.tsv
+KLF17	TranscriptionFactor	addTF_JL.tsv
+KLF2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+KLF3	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+KLF4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+KLF5	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+KLF6	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+KLF7	TranscriptionFactor	addTF_JL.tsv
+KLF8	TranscriptionFactor	addTF_JL.tsv
+KLF9	TranscriptionFactor	addTF_JL.tsv
+KLHL6	Oncogene, TumorSuppressorGene	OncoKBv20240704
+KLK10	TumorSuppressorGene	TumorSuppressorGene.txt
+KLK2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KLK6	TumorSuppressorGene	TumorSuppressorGene.txt
+KMT2A	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+KMT2B	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+KMT2C	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+KMT2D	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+KNL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KNSTRN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+KRAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+KRIT1	TumorSuppressorGene	TumorSuppressorGene.txt
+KRT19	TumorSuppressorGene	TumorSuppressorGene.txt
+KSGCps	Kinase	Kincat_Hsap.08.02.txt
+KSR1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+KSR2	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+KTN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+L3MBTL1	TranscriptionFactor	addTF_JL.tsv
+L3MBTL3	TranscriptionFactor	addTF_JL.tsv
+L3MBTL4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+LARP4B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+LASP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+LAT2	TumorSuppressorGene	TumorSuppressorGene.txt
+LATS1	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+LATS2	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+LBX1	TranscriptionFactor	addTF_JL.tsv
+LBX2	TranscriptionFactor	addTF_JL.tsv
+LCK	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+LCOR	TranscriptionFactor	addTF_JL.tsv
+LCORL	TranscriptionFactor	addTF_JL.tsv
+LCP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+LEF1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+LEFTY1	TumorSuppressorGene	TumorSuppressorGene.txt
+LEFTY2	TumorSuppressorGene	TumorSuppressorGene.txt
+LEPROTL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+LEUTX	TranscriptionFactor	addTF_JL.tsv
+LGALS7	TumorSuppressorGene	TumorSuppressorGene.txt
+LGR5	Oncogene	OncoKBv20240704
+LHFPL6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+LHX1	TranscriptionFactor	addTF_JL.tsv
+LHX2	TranscriptionFactor	addTF_JL.tsv
+LHX3	TranscriptionFactor	addTF_JL.tsv
+LHX4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+LHX5	TranscriptionFactor	addTF_JL.tsv
+LHX6	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+LHX8	TranscriptionFactor	addTF_JL.tsv
+LHX9	TranscriptionFactor	addTF_JL.tsv
+LIFR	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+LIMA1	TumorSuppressorGene	TumorSuppressorGene.txt
+LIMD1	TumorSuppressorGene	TumorSuppressorGene.txt
+LIMK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+LIMK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+LIMK2ps	Kinase	Kincat_Hsap.08.02.txt
+LIN28A	TranscriptionFactor	addTF_JL.tsv
+LIN28B	TranscriptionFactor	addTF_JL.tsv
+LIN54	TranscriptionFactor	addTF_JL.tsv
+LIN9	TumorSuppressorGene	TumorSuppressorGene.txt
+LINC-PINT	TumorSuppressorGene	TumorSuppressorGene.txt
+LITAF	TumorSuppressorGene	TumorSuppressorGene.txt
+LKB1	Kinase	Kincat_Hsap.08.02.txt
+LLGL1	TumorSuppressorGene	TumorSuppressorGene.txt
+LMNA	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+LMNTD1	TumorSuppressorGene	TumorSuppressorGene.txt
+LMO1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+LMO2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+LMR1	Kinase	Kincat_Hsap.08.02.txt
+LMR2	Kinase	Kincat_Hsap.08.02.txt
+LMR3	Kinase	Kincat_Hsap.08.02.txt
+LMTK2	Kinase	PfamKinase
+LMTK3	Kinase	PfamKinase
+LMX1A	TranscriptionFactor	addTF_JL.tsv
+LMX1B	TranscriptionFactor	addTF_JL.tsv
+LOC401317	TumorSuppressorGene	TumorSuppressorGene.txt
+LOK	Kinase	Kincat_Hsap.08.02.txt
+LOX	TumorSuppressorGene	TumorSuppressorGene.txt
+LPP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+LRIG1	TumorSuppressorGene	TumorSuppressorGene.txt
+LRIG3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+LRMP	TumorSuppressorGene	TumorSuppressorGene.txt
+LRP1B	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+LRP5	Oncogene, TumorSuppressorGene	OncoKBv20240704
+LRP6	Oncogene	OncoKBv20240704
+LRRC3B	TumorSuppressorGene	TumorSuppressorGene.txt
+LRRC4	TumorSuppressorGene	TumorSuppressorGene.txt
+LRRK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+LRRK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+LSAMP	TumorSuppressorGene	TumorSuppressorGene.txt
+LSM14A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+LTB	Oncogene, TumorSuppressorGene	OncoKBv20240704
+LTF	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+LTK	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+LXN	TumorSuppressorGene	TumorSuppressorGene.txt
+LYL1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+LYN	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+LZK	Kinase	Kincat_Hsap.08.02.txt
+LZTR1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+LZTS1	TumorSuppressorGene	TumorSuppressorGene.txt
+MACC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MAD1L1	TumorSuppressorGene	TumorSuppressorGene.txt
+MAD2L2	Oncogene, TumorSuppressorGene	OncoKBv20240704
+MADD	TumorSuppressorGene	TumorSuppressorGene.txt
+MAF	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+MAFA	TranscriptionFactor	addTF_JL.tsv
+MAFB	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MAFF	TranscriptionFactor	addTF_JL.tsv
+MAFG	TranscriptionFactor	addTF_JL.tsv
+MAFK	TranscriptionFactor	addTF_JL.tsv
+MAK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAL	TumorSuppressorGene	TumorSuppressorGene.txt
+MAL2	TumorSuppressorGene	OncoKBv20240704
+MALAT1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MALT1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MAML2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MAP2K1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+MAP2K1ps	Kinase	Kincat_Hsap.08.02.txt
+MAP2K2	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+MAP2K2ps	Kinase	Kincat_Hsap.08.02.txt
+MAP2K3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP2K4	Kinase, TumorSuppressorGene, CosmicCensus	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+MAP2K5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP2K6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP2K7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP3K1	Kinase, CosmicCensus, TumorSuppressorGene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+MAP3K10	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP3K11	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP3K12	Kinase	PfamKinase
+MAP3K13	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+MAP3K14	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+MAP3K15	Kinase	PfamKinase
+MAP3K19	Kinase	PfamKinase
+MAP3K2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP3K20	Kinase	PfamKinase
+MAP3K21	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+MAP3K3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP3K4	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+MAP3K5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP3K6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP3K7	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+MAP3K8	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+MAP3K9	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAP4K1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+MAP4K2	Kinase	PfamKinase
+MAP4K3	Kinase	PfamKinase
+MAP4K4	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+MAP4K5	Kinase	PfamKinase
+MAPK1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+MAPK10	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+MAPK11	Kinase	PfamKinase
+MAPK12	Kinase	PfamKinase
+MAPK13	Kinase	PfamKinase
+MAPK14	Kinase	PfamKinase
+MAPK15	Kinase	PfamKinase
+MAPK3	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+MAPK4	Kinase	PfamKinase
+MAPK6	Kinase	PfamKinase
+MAPK7	Kinase	PfamKinase
+MAPK8	Kinase	PfamKinase
+MAPK9	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+MAPKAPK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAPKAPK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAPKAPK5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAPKAPKps1	Kinase	Kincat_Hsap.08.02.txt
+MARCKS	TumorSuppressorGene	TumorSuppressorGene.txt
+MARK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MARK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MARK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MARK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MARKps01	Kinase	Kincat_Hsap.08.02.txt
+MARKps02	Kinase	Kincat_Hsap.08.02.txt
+MARKps03	Kinase	Kincat_Hsap.08.02.txt
+MARKps04	Kinase	Kincat_Hsap.08.02.txt
+MARKps05	Kinase	Kincat_Hsap.08.02.txt
+MARKps07	Kinase	Kincat_Hsap.08.02.txt
+MARKps08	Kinase	Kincat_Hsap.08.02.txt
+MARKps09	Kinase	Kincat_Hsap.08.02.txt
+MARKps10	Kinase	Kincat_Hsap.08.02.txt
+MARKps11	Kinase	Kincat_Hsap.08.02.txt
+MARKps12	Kinase	Kincat_Hsap.08.02.txt
+MARKps13	Kinase	Kincat_Hsap.08.02.txt
+MARKps15	Kinase	Kincat_Hsap.08.02.txt
+MARKps16	Kinase	Kincat_Hsap.08.02.txt
+MARKps17	Kinase	Kincat_Hsap.08.02.txt
+MARKps18	Kinase	Kincat_Hsap.08.02.txt
+MARKps19	Kinase	Kincat_Hsap.08.02.txt
+MARKps20	Kinase	Kincat_Hsap.08.02.txt
+MARKps21	Kinase	Kincat_Hsap.08.02.txt
+MARKps22	Kinase	Kincat_Hsap.08.02.txt
+MARKps23	Kinase	Kincat_Hsap.08.02.txt
+MARKps24	Kinase	Kincat_Hsap.08.02.txt
+MARKps25	Kinase	Kincat_Hsap.08.02.txt
+MARKps26	Kinase	Kincat_Hsap.08.02.txt
+MARKps27	Kinase	Kincat_Hsap.08.02.txt
+MARKps28	Kinase	Kincat_Hsap.08.02.txt
+MARKps29	Kinase	Kincat_Hsap.08.02.txt
+MARKps30	Kinase	Kincat_Hsap.08.02.txt
+MARVELD1	TumorSuppressorGene	TumorSuppressorGene.txt
+MAST1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAST2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAST3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAST4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MASTL	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MAT2A	TumorSuppressorGene	TumorSuppressorGene.txt
+MATK	Kinase	PfamKinase
+MAX	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MAZ	TranscriptionFactor	addTF_JL.tsv
+MB21D2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MBD1	TranscriptionFactor	addTF_JL.tsv
+MBD2	TranscriptionFactor	addTF_JL.tsv
+MBD3	TranscriptionFactor	addTF_JL.tsv
+MBD4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+MBD6	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+MBNL2	TranscriptionFactor	addTF_JL.tsv
+MCC	TumorSuppressorGene	TumorSuppressorGene.txt
+MCL1	Oncogene	OncoKBv20240704
+MCM9	TumorSuppressorGene	TumorSuppressorGene.txt
+MCPH1	TumorSuppressorGene	TumorSuppressorGene.txt
+MDC1	TumorSuppressorGene	TumorSuppressorGene.txt
+MDM2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MDM4	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MDS2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MECOM	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MECP2	TranscriptionFactor	addTF_JL.tsv
+MED12	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MEF2A	TranscriptionFactor	addTF_JL.tsv
+MEF2B	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+MEF2C	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+MEF2D	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+MEG3	TumorSuppressorGene	TumorSuppressorGene.txt
+MEIS1	TranscriptionFactor	addTF_JL.tsv
+MEIS2	TranscriptionFactor	addTF_JL.tsv
+MEIS3	TranscriptionFactor	addTF_JL.tsv
+MEIS3P1	TranscriptionFactor	addTF_JL.tsv
+MELK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MEN1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MEOX1	TranscriptionFactor	addTF_JL.tsv
+MEOX2	TranscriptionFactor	addTF_JL.tsv
+MER	Kinase	Kincat_Hsap.08.02.txt
+MERTK	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+MESP1	TranscriptionFactor	addTF_JL.tsv
+MESP2	TranscriptionFactor	addTF_JL.tsv
+MET	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+MFSD2A	TumorSuppressorGene	TumorSuppressorGene.txt
+MGA	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+MGAM	Oncogene	OncoKBv20240704
+MGMT	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MIA	TumorSuppressorGene	TumorSuppressorGene.txt
+MIA2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIDEAS	TumorSuppressorGene	OncoKBv20240704
+MINDY3	TumorSuppressorGene	TumorSuppressorGene.txt
+MINK	Kinase	Kincat_Hsap.08.02.txt
+MINK1	Kinase	PfamKinase
+MIR1-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR1-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR100	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR101-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR101-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR106A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR107	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR10A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR122	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR1226	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR124-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR124-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR124-3	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR1247	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR125A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR125B1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR125B2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR126	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR127	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR129-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR129-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR1291	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR1297	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR130A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR132	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR133A1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR133A2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR134	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR135A1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR135A2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR136	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR137	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR138-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR138-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR140	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR141	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR142	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR143	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR145	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR146A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR147A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR148A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR148B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR149	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR150	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR152	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR155	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR15A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR16-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR16-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR17	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR181A1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR181A2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR181B1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR181B2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR181C	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR182	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR183	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR185	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR186	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR187	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR18A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR18B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR192	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR193A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR193B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR194-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR194-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR195	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR196A2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR196B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR198	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR199A1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR200A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR200B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR200C	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR203A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR204	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR205	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR206	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR20A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR210	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR211	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR214	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR215	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR217	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR218-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR218-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR219A1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR22	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR222	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR223	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR23A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR23B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR24-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR25	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR26A1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR26A2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR26B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR27A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR27B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR28	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR296	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR29A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR29B1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR29C	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR302B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR30A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR30C1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR31	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR320A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR326	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR329-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR335	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR338	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR33A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR340	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR34A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR34B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR34C	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR367	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR370	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR375	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR378A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR383	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR409	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR410	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR422A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR424	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR449A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR449B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR451A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR483	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR486-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR487B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR490	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR493	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR494	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR495	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR497	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR502	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR503	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR504	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR505	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR508	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR509-3	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR511	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR517A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR519D	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR520B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR520C	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR551A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR574	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR615	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR636	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR7-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR7-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR7-3	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR708	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR874	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR888	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR9-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR9-2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR9-3	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR941-1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR98	TumorSuppressorGene	TumorSuppressorGene.txt
+MIR99A	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7A1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7A2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7A3	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7B	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7C	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7D	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7E	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7F1	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7F2	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7G	TumorSuppressorGene	TumorSuppressorGene.txt
+MIRLET7I	TumorSuppressorGene	TumorSuppressorGene.txt
+MISR2	Kinase	Kincat_Hsap.08.02.txt
+MITF	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MIXL1	TranscriptionFactor	addTF_JL.tsv
+MKI67	Oncogene	OncoKBv20240704
+MKNK1	Kinase	PfamKinase
+MKNK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MKX	TranscriptionFactor	addTF_JL.tsv
+MLF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MLH1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MLH3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+MLK1	Kinase	Kincat_Hsap.08.02.txt
+MLK2	Kinase	Kincat_Hsap.08.02.txt
+MLK3	Kinase	Kincat_Hsap.08.02.txt
+MLK4	Kinase	Kincat_Hsap.08.02.txt
+MLKL	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MLLT1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MLLT10	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MLLT11	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MLLT3	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MLLT6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MLX	TranscriptionFactor	addTF_JL.tsv
+MLXIP	TranscriptionFactor	addTF_JL.tsv
+MLXIPL	TranscriptionFactor	addTF_JL.tsv
+MME	TumorSuppressorGene	TumorSuppressorGene.txt
+MN1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MNK1	Kinase	Kincat_Hsap.08.02.txt
+MNK1ps	Kinase	Kincat_Hsap.08.02.txt
+MNK2	Kinase	Kincat_Hsap.08.02.txt
+MNT	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+MNX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+MOB1A	TumorSuppressorGene	TumorSuppressorGene.txt
+MOB1B	TumorSuppressorGene	TumorSuppressorGene.txt
+MOB3B	TumorSuppressorGene	OncoKBv20240704
+MOK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MOS	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MPL	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MPSK1	Kinase	Kincat_Hsap.08.02.txt
+MPSK1ps	Kinase	Kincat_Hsap.08.02.txt
+MRCKa	Kinase	Kincat_Hsap.08.02.txt
+MRCKb	Kinase	Kincat_Hsap.08.02.txt
+MRCKps	Kinase	Kincat_Hsap.08.02.txt
+MRE11	TumorSuppressorGene	OncoKBv20240704
+MRTFA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MRVI1	TumorSuppressorGene	TumorSuppressorGene.txt
+MSANTD1	TranscriptionFactor	addTF_JL.tsv
+MSANTD3	TranscriptionFactor	addTF_JL.tsv
+MSANTD4	TranscriptionFactor	addTF_JL.tsv
+MSC	TranscriptionFactor	addTF_JL.tsv
+MSGN1	TranscriptionFactor	addTF_JL.tsv
+MSH2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MSH3	TumorSuppressorGene	OncoKBv20240704
+MSH6	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MSI1	Oncogene	OncoKBv20240704
+MSI2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MSK1	Kinase	Kincat_Hsap.08.02.txt
+MSK2	Kinase	Kincat_Hsap.08.02.txt
+MSMB	TumorSuppressorGene	TumorSuppressorGene.txt
+MSN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MSSK1	Kinase	Kincat_Hsap.08.02.txt
+MST1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, OncoKBv20240704
+MST1R	Kinase, Oncogene, TumorSuppressorGene	Kincat_Hsap.08.02.txt, OncoKBv20240704, TumorSuppressorGene.txt, PfamKinase
+MST2	Kinase	Kincat_Hsap.08.02.txt
+MST3	Kinase	Kincat_Hsap.08.02.txt
+MST3ps	Kinase	Kincat_Hsap.08.02.txt
+MST4	Kinase	Kincat_Hsap.08.02.txt
+MSX1	TranscriptionFactor	addTF_JL.tsv
+MSX2	TranscriptionFactor	addTF_JL.tsv
+MT1DP	TumorSuppressorGene	TumorSuppressorGene.txt
+MT1F	TumorSuppressorGene	TumorSuppressorGene.txt
+MT1G	TumorSuppressorGene	TumorSuppressorGene.txt
+MT1M	TumorSuppressorGene	TumorSuppressorGene.txt
+MT2A	TumorSuppressorGene	TumorSuppressorGene.txt
+MTAP	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+MTCP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MTERF1	TranscriptionFactor	addTF_JL.tsv
+MTERF2	TranscriptionFactor	addTF_JL.tsv
+MTERF3	TranscriptionFactor	addTF_JL.tsv
+MTERF4	TranscriptionFactor	addTF_JL.tsv
+MTF1	TranscriptionFactor	addTF_JL.tsv
+MTF2	TranscriptionFactor	addTF_JL.tsv
+MTHFD2	Oncogene	OncoKBv20240704
+MTOR	Kinase, Oncogene, CosmicCensus	Kincat_Hsap.08.02.txt, OncoKBv20240704, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+MTSS1	TumorSuppressorGene	TumorSuppressorGene.txt
+MTUS1	TumorSuppressorGene	TumorSuppressorGene.txt
+MUC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MUC16	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MUC4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+MUS81	TumorSuppressorGene	TumorSuppressorGene.txt
+MUSK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MUTYH	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MVD	Kinase	PfamKinase
+MVK	Kinase	PfamKinase
+MXD1	TranscriptionFactor	addTF_JL.tsv
+MXD3	TranscriptionFactor	addTF_JL.tsv
+MXD4	TranscriptionFactor	addTF_JL.tsv
+MXI1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+MYB	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MYBBP1A	TumorSuppressorGene	TumorSuppressorGene.txt
+MYBL1	TranscriptionFactor, Oncogene	addTF_JL.tsv, AddedallOnco_Feb2017.tsv, OncoKBv20240704
+MYBL2	TranscriptionFactor	addTF_JL.tsv
+MYC	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MYCL	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MYCN	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MYD88	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MYF5	TranscriptionFactor	addTF_JL.tsv
+MYF6	TranscriptionFactor	addTF_JL.tsv
+MYH11	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MYH9	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+MYLK	Kinase	PfamKinase
+MYLK2	Kinase	PfamKinase
+MYLK3	Kinase	PfamKinase
+MYLK4	Kinase	PfamKinase
+MYNN	TranscriptionFactor	addTF_JL.tsv
+MYO18B	TumorSuppressorGene	TumorSuppressorGene.txt
+MYO1A	TumorSuppressorGene	TumorSuppressorGene.txt
+MYO3A	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MYO3B	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+MYO5A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+MYOD1	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+MYOG	TranscriptionFactor	addTF_JL.tsv
+MYPOP	TranscriptionFactor	addTF_JL.tsv
+MYRF	TranscriptionFactor	addTF_JL.tsv
+MYRFL	TranscriptionFactor	addTF_JL.tsv
+MYSM1	TranscriptionFactor	addTF_JL.tsv
+MYT1	Kinase, TranscriptionFactor	Kincat_Hsap.08.02.txt, addTF_JL.tsv
+MYT1L	TranscriptionFactor	addTF_JL.tsv
+MZB1	TumorSuppressorGene	TumorSuppressorGene.txt
+MZF1	TranscriptionFactor	addTF_JL.tsv
+N4BP2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NAB2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NACA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NACC2	TranscriptionFactor	addTF_JL.tsv
+NADK	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+NADK2	Kinase	PfamKinase
+NAIF1	TranscriptionFactor	addTF_JL.tsv
+NANOG	TranscriptionFactor	addTF_JL.tsv
+NANOGNB	TranscriptionFactor	addTF_JL.tsv
+NANOGP8	TranscriptionFactor	addTF_JL.tsv
+NAPEPLD	TumorSuppressorGene	TumorSuppressorGene.txt
+NAXD	Kinase	PfamKinase
+NBEA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NBN	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NCKIPSD	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NCOA1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+NCOA2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+NCOA3	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+NCOA4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+NCOA5	TumorSuppressorGene	TumorSuppressorGene.txt
+NCOR1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NCOR2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NCSTN	Oncogene	OncoKBv20240704
+NDN	TumorSuppressorGene	TumorSuppressorGene.txt
+NDR1	Kinase	Kincat_Hsap.08.02.txt
+NDR2	Kinase	Kincat_Hsap.08.02.txt
+NDRG1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+NDRG2	TumorSuppressorGene	TumorSuppressorGene.txt
+NDRG4	TumorSuppressorGene	TumorSuppressorGene.txt
+NDST4	TumorSuppressorGene	TumorSuppressorGene.txt
+NEDD4	TumorSuppressorGene	TumorSuppressorGene.txt
+NEDD4L	TumorSuppressorGene	TumorSuppressorGene.txt
+NEK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK10	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK11	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK2ps1	Kinase	Kincat_Hsap.08.02.txt
+NEK2ps2	Kinase	Kincat_Hsap.08.02.txt
+NEK2ps3	Kinase	Kincat_Hsap.08.02.txt
+NEK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK4ps	Kinase	Kincat_Hsap.08.02.txt
+NEK5	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK7	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK8	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEK9	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NEURL1	TumorSuppressorGene	TumorSuppressorGene.txt
+NEUROD1	TranscriptionFactor	addTF_JL.tsv
+NEUROD2	TranscriptionFactor	addTF_JL.tsv
+NEUROD4	TranscriptionFactor	addTF_JL.tsv
+NEUROD6	TranscriptionFactor	addTF_JL.tsv
+NEUROG1	TranscriptionFactor	addTF_JL.tsv
+NEUROG2	TranscriptionFactor	addTF_JL.tsv
+NEUROG3	TranscriptionFactor	addTF_JL.tsv
+NF1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NF2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NFAT5	TranscriptionFactor	addTF_JL.tsv
+NFATC1	TranscriptionFactor	addTF_JL.tsv
+NFATC2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+NFATC3	TranscriptionFactor	addTF_JL.tsv
+NFATC4	TranscriptionFactor	addTF_JL.tsv
+NFE2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+NFE2L1	TranscriptionFactor	addTF_JL.tsv
+NFE2L2	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+NFE2L3	TranscriptionFactor	addTF_JL.tsv
+NFE4	TranscriptionFactor	addTF_JL.tsv
+NFIA	TranscriptionFactor	addTF_JL.tsv
+NFIB	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+NFIC	TranscriptionFactor	addTF_JL.tsv
+NFIL3	TranscriptionFactor	addTF_JL.tsv
+NFIX	TranscriptionFactor	addTF_JL.tsv
+NFKB1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+NFKB2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+NFKBIA	TumorSuppressorGene	OncoKBv20240704
+NFKBIE	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NFX1	TranscriptionFactor	addTF_JL.tsv
+NFXL1	TranscriptionFactor	addTF_JL.tsv
+NFYA	TranscriptionFactor	addTF_JL.tsv
+NFYB	TranscriptionFactor	addTF_JL.tsv
+NFYC	TranscriptionFactor	addTF_JL.tsv
+NGFR	TumorSuppressorGene	TumorSuppressorGene.txt
+NHERF1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+NHLH1	TranscriptionFactor	addTF_JL.tsv
+NHLH2	TranscriptionFactor	addTF_JL.tsv
+NIK	Kinase	Kincat_Hsap.08.02.txt
+NIM1	Kinase	Kincat_Hsap.08.02.txt
+NIM1K	Kinase	PfamKinase
+NIN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NINJ1	TumorSuppressorGene	TumorSuppressorGene.txt
+NIT2	TumorSuppressorGene	TumorSuppressorGene.txt
+NKRF	TranscriptionFactor	addTF_JL.tsv
+NKX1-1	TranscriptionFactor	addTF_JL.tsv
+NKX1-2	TranscriptionFactor	addTF_JL.tsv
+NKX2-1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+NKX2-2	TranscriptionFactor	addTF_JL.tsv
+NKX2-3	TranscriptionFactor	addTF_JL.tsv
+NKX2-4	TranscriptionFactor	addTF_JL.tsv
+NKX2-5	TranscriptionFactor	addTF_JL.tsv
+NKX2-6	TranscriptionFactor	addTF_JL.tsv
+NKX2-8	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+NKX3-1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+NKX3-2	TranscriptionFactor	addTF_JL.tsv
+NKX6-1	TranscriptionFactor	addTF_JL.tsv
+NKX6-2	TranscriptionFactor	addTF_JL.tsv
+NKX6-3	TranscriptionFactor	addTF_JL.tsv
+NLK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NME1	TumorSuppressorGene	TumorSuppressorGene.txt
+NME2	TranscriptionFactor	addTF_JL.tsv
+NNAT	TumorSuppressorGene	TumorSuppressorGene.txt
+NOBOX	TranscriptionFactor	addTF_JL.tsv
+NOL7	TumorSuppressorGene	TumorSuppressorGene.txt
+NONO	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NOP53	TumorSuppressorGene	TumorSuppressorGene.txt
+NOTCH1	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NOTCH2	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NOTCH3	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+NOTCH4	Oncogene, TumorSuppressorGene	OncoKBv20240704
+NOTO	TranscriptionFactor	addTF_JL.tsv
+NOV	TumorSuppressorGene	TumorSuppressorGene.txt
+NPAS1	TranscriptionFactor	addTF_JL.tsv
+NPAS2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+NPAS3	TranscriptionFactor	addTF_JL.tsv
+NPAS4	TranscriptionFactor	addTF_JL.tsv
+NPM1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NPR1	Kinase	PfamKinase
+NPR2	Kinase	PfamKinase
+NPRL2	TumorSuppressorGene	TumorSuppressorGene.txt
+NQO1	Oncogene	OncoKBv20240704
+NR0B1	TranscriptionFactor	addTF_JL.tsv
+NR0B2	TumorSuppressorGene	TumorSuppressorGene.txt
+NR1D1	TranscriptionFactor	addTF_JL.tsv
+NR1D2	TranscriptionFactor	addTF_JL.tsv
+NR1H2	TranscriptionFactor	addTF_JL.tsv
+NR1H3	TranscriptionFactor	addTF_JL.tsv
+NR1H4	TranscriptionFactor	addTF_JL.tsv
+NR1I2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+NR1I3	TranscriptionFactor	addTF_JL.tsv
+NR2C1	TranscriptionFactor	addTF_JL.tsv
+NR2C2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+NR2E1	TranscriptionFactor	addTF_JL.tsv
+NR2E3	TranscriptionFactor	addTF_JL.tsv
+NR2F1	TranscriptionFactor	addTF_JL.tsv
+NR2F2	TranscriptionFactor	addTF_JL.tsv
+NR2F6	TranscriptionFactor	addTF_JL.tsv
+NR3C1	TranscriptionFactor	addTF_JL.tsv
+NR3C2	TranscriptionFactor	addTF_JL.tsv
+NR4A1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+NR4A2	TranscriptionFactor	addTF_JL.tsv
+NR4A3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+NR5A1	TranscriptionFactor	addTF_JL.tsv
+NR5A2	TranscriptionFactor	addTF_JL.tsv
+NR6A1	TranscriptionFactor	addTF_JL.tsv
+NRAS	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NRBP1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+NRBP2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NRCAM	TumorSuppressorGene	TumorSuppressorGene.txt
+NRF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+NRG1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NRK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+NRL	TranscriptionFactor	addTF_JL.tsv
+NRSN2	TumorSuppressorGene	TumorSuppressorGene.txt
+NSD1	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NSD2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NSD3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+NT5C2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NTHL1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NTRK1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+NTRK2	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+NTRK3	TumorSuppressorGene, CosmicCensus, Kinase, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+NUAK1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+NUAK2	Kinase	PfamKinase
+NUF2	Oncogene	OncoKBv20240704
+NUMA1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NUMB	TumorSuppressorGene	TumorSuppressorGene.txt
+NUP214	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NUP98	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+NUPR1	TumorSuppressorGene	TumorSuppressorGene.txt
+NUTM1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NUTM2B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NUTM2D	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+NuaK1	Kinase	Kincat_Hsap.08.02.txt
+NuaK2	Kinase	Kincat_Hsap.08.02.txt
+OBSCN	Kinase	PfamKinase
+OLFM4	TumorSuppressorGene	TumorSuppressorGene.txt
+OLIG1	TranscriptionFactor	addTF_JL.tsv
+OLIG2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+OLIG3	TranscriptionFactor	addTF_JL.tsv
+OMD	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ONECUT1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ONECUT2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+ONECUT3	TranscriptionFactor	addTF_JL.tsv
+OPCML	TumorSuppressorGene	TumorSuppressorGene.txt
+OSCP1	TumorSuppressorGene	TumorSuppressorGene.txt
+OSGIN1	TumorSuppressorGene	TumorSuppressorGene.txt
+OSR1	Kinase, TranscriptionFactor	Kincat_Hsap.08.02.txt, addTF_JL.tsv
+OSR2	TranscriptionFactor	addTF_JL.tsv
+OTP	TranscriptionFactor	addTF_JL.tsv
+OTX1	TranscriptionFactor	addTF_JL.tsv
+OTX2	TranscriptionFactor	addTF_JL.tsv
+OVOL1	TranscriptionFactor	addTF_JL.tsv
+OVOL2	TranscriptionFactor	addTF_JL.tsv
+OVOL3	TranscriptionFactor	addTF_JL.tsv
+OXSR1	Kinase, TranscriptionFactor	Kincat_Hsap.08.02.txt, addTF_JL.tsv, PfamKinase
+Obscn	Kinase	Kincat_Hsap.08.02.txt
+P2RY8	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PA2G4	TranscriptionFactor	addTF_JL.tsv
+PABPC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PACRG	TumorSuppressorGene	TumorSuppressorGene.txt
+PAEP	TumorSuppressorGene	TumorSuppressorGene.txt
+PAFAH1B1	TumorSuppressorGene	TumorSuppressorGene.txt
+PAFAH1B2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PAIP2	TumorSuppressorGene	TumorSuppressorGene.txt
+PAK1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+PAK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PAK2ps	Kinase	Kincat_Hsap.08.02.txt
+PAK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PAK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PAK5	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+PAK6	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PALB2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PANO1	TumorSuppressorGene	TumorSuppressorGene.txt
+PANX2	TumorSuppressorGene	TumorSuppressorGene.txt
+PAPSS1	Kinase	PfamKinase
+PAPSS2	Kinase	PfamKinase
+PARK2	TumorSuppressorGene	TumorSuppressorGene.txt
+PARK7	TumorSuppressorGene	TumorSuppressorGene.txt
+PARP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+PASK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PATZ1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+PAWR	TumorSuppressorGene	TumorSuppressorGene.txt
+PAX1	TranscriptionFactor	addTF_JL.tsv
+PAX2	TranscriptionFactor	addTF_JL.tsv
+PAX3	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+PAX4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PAX5	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+PAX6	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PAX7	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+PAX8	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+PAX9	TranscriptionFactor	addTF_JL.tsv
+PBK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PBRM1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PBX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+PBX2	TranscriptionFactor	addTF_JL.tsv
+PBX2P1	TranscriptionFactor	addTF_JL.tsv
+PBX3	TranscriptionFactor	addTF_JL.tsv
+PBX4	TranscriptionFactor	addTF_JL.tsv
+PCBP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PCDH10	TumorSuppressorGene	TumorSuppressorGene.txt
+PCDH17	TumorSuppressorGene	TumorSuppressorGene.txt
+PCDH8	TumorSuppressorGene	TumorSuppressorGene.txt
+PCDH9	TumorSuppressorGene	TumorSuppressorGene.txt
+PCDHGC3	TumorSuppressorGene	TumorSuppressorGene.txt
+PCGF2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PCGF6	TranscriptionFactor	addTF_JL.tsv
+PCM1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PCTAIRE1	Kinase	Kincat_Hsap.08.02.txt
+PCTAIRE2	Kinase	Kincat_Hsap.08.02.txt
+PCTAIRE3	Kinase	Kincat_Hsap.08.02.txt
+PDCD1	Oncogene	OncoKBv20240704
+PDCD1LG2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PDCD4	TumorSuppressorGene	TumorSuppressorGene.txt
+PDCD5	TumorSuppressorGene	TumorSuppressorGene.txt
+PDE4DIP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PDGFB	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PDGFRA	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+PDGFRB	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+PDGFRL	TumorSuppressorGene	TumorSuppressorGene.txt
+PDGFRa	Kinase	Kincat_Hsap.08.02.txt
+PDGFRb	Kinase	Kincat_Hsap.08.02.txt
+PDHK1	Kinase	Kincat_Hsap.08.02.txt
+PDHK2	Kinase	Kincat_Hsap.08.02.txt
+PDHK3	Kinase	Kincat_Hsap.08.02.txt
+PDHK4	Kinase	Kincat_Hsap.08.02.txt
+PDIK1L	Kinase	PfamKinase
+PDK1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704
+PDLIM4	TumorSuppressorGene	TumorSuppressorGene.txt
+PDPK1	Kinase	PfamKinase
+PDS5B	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+PDSS2	TumorSuppressorGene	TumorSuppressorGene.txt
+PDX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PEA15	TumorSuppressorGene	TumorSuppressorGene.txt
+PEAK1	Kinase	PfamKinase
+PEBP1	TumorSuppressorGene	TumorSuppressorGene.txt
+PEG3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PEK	Kinase	Kincat_Hsap.08.02.txt
+PER1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PER2	TumorSuppressorGene	TumorSuppressorGene.txt
+PF4	TumorSuppressorGene	TumorSuppressorGene.txt
+PFN1	TumorSuppressorGene	TumorSuppressorGene.txt
+PFTAIRE1	Kinase	Kincat_Hsap.08.02.txt
+PFTAIRE2	Kinase	Kincat_Hsap.08.02.txt
+PGBD5	Oncogene	OncoKBv20240704
+PGR	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+PGRMC2	TumorSuppressorGene	TumorSuppressorGene.txt
+PHACTR4	TumorSuppressorGene	TumorSuppressorGene.txt
+PHB	TumorSuppressorGene	TumorSuppressorGene.txt
+PHB1	TumorSuppressorGene	TumorSuppressorGene.txt
+PHC3	TumorSuppressorGene	TumorSuppressorGene.txt
+PHF1	TranscriptionFactor	addTF_JL.tsv
+PHF19	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+PHF20	TranscriptionFactor	addTF_JL.tsv
+PHF21A	TranscriptionFactor	addTF_JL.tsv
+PHF6	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PHIP	TumorSuppressorGene	TumorSuppressorGene.txt
+PHKG1	Kinase	PfamKinase
+PHKG2	Kinase	PfamKinase
+PHKg1	Kinase	Kincat_Hsap.08.02.txt
+PHKg1ps1	Kinase	Kincat_Hsap.08.02.txt
+PHKg1ps2	Kinase	Kincat_Hsap.08.02.txt
+PHKg1ps3	Kinase	Kincat_Hsap.08.02.txt
+PHKg2	Kinase	Kincat_Hsap.08.02.txt
+PHLDA2	TumorSuppressorGene	TumorSuppressorGene.txt
+PHLDA3	TumorSuppressorGene	TumorSuppressorGene.txt
+PHLPP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+PHLPP2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+PHOX2A	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PHOX2B	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+PI4K2B	Kinase	PfamKinase
+PI4KA	Kinase	PfamKinase
+PI4KB	Kinase	PfamKinase
+PIAS1	TumorSuppressorGene	TumorSuppressorGene.txt
+PICALM	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PIERCE2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PIGA	TumorSuppressorGene	OncoKBv20240704
+PIK3C2A	Kinase	PfamKinase
+PIK3C2B	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+PIK3C2G	Kinase	PfamKinase
+PIK3C3	Kinase	PfamKinase
+PIK3CA	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+PIK3CB	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+PIK3CD	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+PIK3CG	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+PIK3R1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PIK3R2	TumorSuppressorGene	OncoKBv20240704
+PIK3R3	TumorSuppressorGene	OncoKBv20240704
+PIK3R4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PIM1	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+PIM2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PIM3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PIN1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PINK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PINX1	TumorSuppressorGene	TumorSuppressorGene.txt
+PITSLRE	Kinase	Kincat_Hsap.08.02.txt
+PITX1	TranscriptionFactor	addTF_JL.tsv
+PITX2	TranscriptionFactor	addTF_JL.tsv
+PITX3	TranscriptionFactor	addTF_JL.tsv
+PIWIL2	TumorSuppressorGene	TumorSuppressorGene.txt
+PKACa	Kinase	Kincat_Hsap.08.02.txt
+PKACb	Kinase	Kincat_Hsap.08.02.txt
+PKACg	Kinase	Kincat_Hsap.08.02.txt
+PKCa	Kinase	Kincat_Hsap.08.02.txt
+PKCb	Kinase	Kincat_Hsap.08.02.txt
+PKCd	Kinase	Kincat_Hsap.08.02.txt
+PKCe	Kinase	Kincat_Hsap.08.02.txt
+PKCg	Kinase	Kincat_Hsap.08.02.txt
+PKCh	Kinase	Kincat_Hsap.08.02.txt
+PKCi	Kinase	Kincat_Hsap.08.02.txt
+PKCips	Kinase	Kincat_Hsap.08.02.txt
+PKCt	Kinase	Kincat_Hsap.08.02.txt
+PKCz	Kinase	Kincat_Hsap.08.02.txt
+PKD1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt
+PKD2	Kinase	Kincat_Hsap.08.02.txt
+PKD3	Kinase	Kincat_Hsap.08.02.txt
+PKG1	Kinase	Kincat_Hsap.08.02.txt
+PKG2	Kinase	Kincat_Hsap.08.02.txt
+PKMYT1	Kinase	PfamKinase
+PKN1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PKN2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PKN3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PKNOX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PKNOX2	TranscriptionFactor	addTF_JL.tsv
+PKR	Kinase	Kincat_Hsap.08.02.txt
+PLA2G16	TumorSuppressorGene	TumorSuppressorGene.txt
+PLA2G2A	TumorSuppressorGene	TumorSuppressorGene.txt
+PLA2G7	TumorSuppressorGene	TumorSuppressorGene.txt
+PLA2R1	TumorSuppressorGene	TumorSuppressorGene.txt
+PLAAT2	TumorSuppressorGene	TumorSuppressorGene.txt
+PLAAT3	TumorSuppressorGene	TumorSuppressorGene.txt
+PLAAT4	TumorSuppressorGene	TumorSuppressorGene.txt
+PLAG1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+PLAGL1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PLAGL2	TranscriptionFactor	addTF_JL.tsv
+PLCB3	TumorSuppressorGene	TumorSuppressorGene.txt
+PLCD1	TumorSuppressorGene	TumorSuppressorGene.txt
+PLCE1	TumorSuppressorGene	TumorSuppressorGene.txt
+PLCG1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PLCG2	Oncogene	OncoKBv20240704
+PLD1	TumorSuppressorGene	TumorSuppressorGene.txt
+PLEKHO1	TumorSuppressorGene	TumorSuppressorGene.txt
+PLK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+PLK1ps1	Kinase	Kincat_Hsap.08.02.txt
+PLK1ps2	Kinase	Kincat_Hsap.08.02.txt
+PLK2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+PLK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PLK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PLK5	TumorSuppressorGene	TumorSuppressorGene.txt
+PLSCR1	TranscriptionFactor	addTF_JL.tsv
+PLXNC1	TumorSuppressorGene	TumorSuppressorGene.txt
+PMAIP1	TumorSuppressorGene	OncoKBv20240704
+PML	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PMS1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PMS2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PMVK	Kinase	PfamKinase
+PNCK	Kinase	PfamKinase
+PNN	TumorSuppressorGene	TumorSuppressorGene.txt
+POGK	TranscriptionFactor	addTF_JL.tsv
+POLD1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+POLE	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+POLG	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+POLQ	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+POMK	Kinase	PfamKinase
+POT1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+POU1F1	TranscriptionFactor	addTF_JL.tsv
+POU2AF1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+POU2F1	TranscriptionFactor	addTF_JL.tsv
+POU2F2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+POU2F3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+POU3F1	TranscriptionFactor	addTF_JL.tsv
+POU3F2	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+POU3F3	TranscriptionFactor	addTF_JL.tsv
+POU3F4	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+POU4F1	TranscriptionFactor	addTF_JL.tsv
+POU4F2	TranscriptionFactor	addTF_JL.tsv
+POU4F3	TranscriptionFactor	addTF_JL.tsv
+POU5F1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+POU5F1B	TranscriptionFactor	addTF_JL.tsv
+POU5F2	TranscriptionFactor	addTF_JL.tsv
+POU6F1	TranscriptionFactor	addTF_JL.tsv
+POU6F2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PPARA	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PPARD	TranscriptionFactor	addTF_JL.tsv
+PPARG	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+PPFIBP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PPM1A	TumorSuppressorGene	TumorSuppressorGene.txt
+PPM1D	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PPM1L	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP1CA	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP1R1B	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP2CA	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP2CB	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP2R1A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PPP2R1B	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP2R2A	TumorSuppressorGene	OncoKBv20240704
+PPP2R2C	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP2R4	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP2R5C	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP3CC	TumorSuppressorGene	TumorSuppressorGene.txt
+PPP6C	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PRAG1	Kinase	PfamKinase
+PRCC	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PRDM1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+PRDM10	TranscriptionFactor	addTF_JL.tsv
+PRDM11	TumorSuppressorGene	TumorSuppressorGene.txt
+PRDM12	TranscriptionFactor	addTF_JL.tsv
+PRDM13	TranscriptionFactor	addTF_JL.tsv
+PRDM14	TranscriptionFactor	addTF_JL.tsv
+PRDM15	TranscriptionFactor	addTF_JL.tsv
+PRDM16	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+PRDM2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+PRDM4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PRDM5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PRDM6	TranscriptionFactor	addTF_JL.tsv
+PRDM8	TranscriptionFactor	addTF_JL.tsv
+PRDM9	TranscriptionFactor	addTF_JL.tsv
+PREB	TranscriptionFactor	addTF_JL.tsv
+PREX2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PRF1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PRICKLE1	TumorSuppressorGene	TumorSuppressorGene.txt
+PRKAA1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+PRKAA2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+PRKACA	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+PRKACB	Kinase	PfamKinase
+PRKACG	Kinase	PfamKinase
+PRKAR1A	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PRKCA	Kinase	PfamKinase
+PRKCB	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+PRKCD	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+PRKCDBP	TumorSuppressorGene	TumorSuppressorGene.txt
+PRKCE	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+PRKCG	Kinase	PfamKinase
+PRKCH	Kinase	PfamKinase
+PRKCI	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+PRKCQ	Kinase	PfamKinase
+PRKCSH	TumorSuppressorGene	TumorSuppressorGene.txt
+PRKCZ	Kinase	PfamKinase
+PRKD1	Kinase	PfamKinase
+PRKD2	Kinase	PfamKinase
+PRKD3	Kinase	PfamKinase
+PRKDC	Kinase, Oncogene, TumorSuppressorGene	PfamKinase, OncoKBv20240704
+PRKG1	Kinase	PfamKinase
+PRKG2	Kinase	PfamKinase
+PRKN	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+PRKX	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PRKXps	Kinase	Kincat_Hsap.08.02.txt
+PRKY	Kinase	Kincat_Hsap.08.02.txt
+PRMT3	TranscriptionFactor	addTF_JL.tsv
+PRODH	TumorSuppressorGene	TumorSuppressorGene.txt
+PROP1	TranscriptionFactor	addTF_JL.tsv
+PROX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+PROX2	TranscriptionFactor	addTF_JL.tsv
+PRP4	Kinase	Kincat_Hsap.08.02.txt
+PRP4ps	Kinase	Kincat_Hsap.08.02.txt
+PRPF40B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PRPF4B	Kinase	PfamKinase
+PRPF8	TumorSuppressorGene	OncoKBv20240704
+PRPK	Kinase	Kincat_Hsap.08.02.txt
+PRR12	TranscriptionFactor	addTF_JL.tsv
+PRR5	TumorSuppressorGene	TumorSuppressorGene.txt
+PRRX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+PRRX2	TranscriptionFactor	addTF_JL.tsv
+PSIP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PSKH1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PSKH1ps	Kinase	Kincat_Hsap.08.02.txt
+PSKH2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+PSMB2	Oncogene	OncoKBv20240704
+PTCH1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PTCH2	TumorSuppressorGene	TumorSuppressorGene.txt
+PTCSC3	TumorSuppressorGene	TumorSuppressorGene.txt
+PTEN	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PTENP1	TumorSuppressorGene	TumorSuppressorGene.txt
+PTF1A	TranscriptionFactor	addTF_JL.tsv
+PTGDR	TumorSuppressorGene	TumorSuppressorGene.txt
+PTK2	Kinase	PfamKinase
+PTK2B	Kinase	PfamKinase
+PTK6	CosmicCensus, Kinase	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+PTK7	Kinase	PfamKinase
+PTPA	TumorSuppressorGene	TumorSuppressorGene.txt
+PTPN1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+PTPN11	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PTPN12	TumorSuppressorGene	TumorSuppressorGene.txt
+PTPN13	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PTPN14	TumorSuppressorGene	OncoKBv20240704
+PTPN2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+PTPN23	TumorSuppressorGene	TumorSuppressorGene.txt
+PTPN6	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+PTPRB	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PTPRC	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+PTPRD	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PTPRJ	TumorSuppressorGene	TumorSuppressorGene.txt
+PTPRK	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+PTPRS	TumorSuppressorGene	OncoKBv20240704
+PTPRT	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+PURA	TranscriptionFactor	addTF_JL.tsv
+PURB	TranscriptionFactor	addTF_JL.tsv
+PURG	TranscriptionFactor	addTF_JL.tsv
+PWAR4	TumorSuppressorGene	TumorSuppressorGene.txt
+PWWP2A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+PYCARD	TumorSuppressorGene	TumorSuppressorGene.txt
+PYHIN1	TumorSuppressorGene	TumorSuppressorGene.txt
+PYK2	Kinase	Kincat_Hsap.08.02.txt
+QIK	Kinase	Kincat_Hsap.08.02.txt
+QKI	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+QSK	Kinase	Kincat_Hsap.08.02.txt
+RAB25	TumorSuppressorGene	TumorSuppressorGene.txt
+RAB35	Oncogene	OncoKBv20240704
+RAB7A	TumorSuppressorGene	TumorSuppressorGene.txt
+RABEP1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RAC1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RAC2	Oncogene	OncoKBv20240704
+RACK1	TumorSuppressorGene	TumorSuppressorGene.txt
+RAD17	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RAD21	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RAD23B	TumorSuppressorGene	TumorSuppressorGene.txt
+RAD50	TumorSuppressorGene	OncoKBv20240704
+RAD51	TumorSuppressorGene	OncoKBv20240704
+RAD51B	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RAD51C	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+RAD51D	TumorSuppressorGene	OncoKBv20240704
+RAF1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+RAF1ps	Kinase	Kincat_Hsap.08.02.txt
+RAG1	TranscriptionFactor	addTF_JL.tsv
+RALGDS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RANBP2	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RANBP9	TumorSuppressorGene	TumorSuppressorGene.txt
+RAP1A	TumorSuppressorGene	TumorSuppressorGene.txt
+RAP1GAP	TumorSuppressorGene	TumorSuppressorGene.txt
+RAP1GDS1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RARA	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+RARB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+RARG	TranscriptionFactor	addTF_JL.tsv
+RARRES3	TumorSuppressorGene	TumorSuppressorGene.txt
+RASA1	TumorSuppressorGene	OncoKBv20240704
+RASAL1	TumorSuppressorGene	TumorSuppressorGene.txt
+RASAL2	TumorSuppressorGene	TumorSuppressorGene.txt
+RASL10A	TumorSuppressorGene	TumorSuppressorGene.txt
+RASL10B	TumorSuppressorGene	TumorSuppressorGene.txt
+RASL11A	TumorSuppressorGene	TumorSuppressorGene.txt
+RASSF1	TumorSuppressorGene	TumorSuppressorGene.txt
+RASSF10	TumorSuppressorGene	TumorSuppressorGene.txt
+RASSF2	TumorSuppressorGene	TumorSuppressorGene.txt
+RASSF3	TumorSuppressorGene	TumorSuppressorGene.txt
+RASSF4	TumorSuppressorGene	TumorSuppressorGene.txt
+RASSF5	TumorSuppressorGene	TumorSuppressorGene.txt
+RASSF8	TumorSuppressorGene	TumorSuppressorGene.txt
+RAX	TranscriptionFactor	addTF_JL.tsv
+RAX2	TranscriptionFactor	addTF_JL.tsv
+RB1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RB1CC1	TumorSuppressorGene	TumorSuppressorGene.txt
+RBAK	TranscriptionFactor	addTF_JL.tsv
+RBBP7	TumorSuppressorGene	TumorSuppressorGene.txt
+RBBP8	TumorSuppressorGene	TumorSuppressorGene.txt
+RBCK1	TranscriptionFactor	addTF_JL.tsv
+RBL1	TumorSuppressorGene	TumorSuppressorGene.txt
+RBL2	TumorSuppressorGene	TumorSuppressorGene.txt
+RBM10	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RBM14	TumorSuppressorGene	TumorSuppressorGene.txt
+RBM15	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RBM38	TumorSuppressorGene	TumorSuppressorGene.txt
+RBM4	TumorSuppressorGene	TumorSuppressorGene.txt
+RBM5	TumorSuppressorGene	TumorSuppressorGene.txt
+RBM6	TumorSuppressorGene	TumorSuppressorGene.txt
+RBMS3	TumorSuppressorGene	TumorSuppressorGene.txt
+RBMX	TumorSuppressorGene	TumorSuppressorGene.txt
+RBP1	TumorSuppressorGene	TumorSuppressorGene.txt
+RBPJ	TranscriptionFactor	addTF_JL.tsv
+RBPJL	TranscriptionFactor	addTF_JL.tsv
+RBSN	TranscriptionFactor	addTF_JL.tsv
+RCHY1	TumorSuppressorGene	TumorSuppressorGene.txt
+RECK	TumorSuppressorGene	TumorSuppressorGene.txt
+RECQL	TumorSuppressorGene	OncoKBv20240704
+RECQL4	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+REL	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+RELA	TranscriptionFactor	addTF_JL.tsv
+RELB	TranscriptionFactor	addTF_JL.tsv
+REPIN1	TranscriptionFactor	addTF_JL.tsv
+REST	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+RET	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+REV3L	Oncogene	OncoKBv20240704
+REXO4	TranscriptionFactor	addTF_JL.tsv
+RFK	Kinase	PfamKinase
+RFWD2	TumorSuppressorGene	TumorSuppressorGene.txt
+RFWD3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RFX1	TranscriptionFactor	addTF_JL.tsv
+RFX2	TranscriptionFactor	addTF_JL.tsv
+RFX3	TranscriptionFactor	addTF_JL.tsv
+RFX4	TranscriptionFactor	addTF_JL.tsv
+RFX5	TranscriptionFactor	addTF_JL.tsv
+RFX6	TranscriptionFactor	addTF_JL.tsv
+RFX7	TranscriptionFactor	addTF_JL.tsv
+RFX8	TranscriptionFactor	addTF_JL.tsv
+RGPD3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RGS7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RHEB	Oncogene	OncoKBv20240704
+RHOA	TumorSuppressorGene, CosmicCensus, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RHOB	TumorSuppressorGene	TumorSuppressorGene.txt
+RHOBTB2	TumorSuppressorGene	TumorSuppressorGene.txt
+RHOH	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RHOK	Kinase	Kincat_Hsap.08.02.txt
+RHOXF1	TranscriptionFactor	addTF_JL.tsv
+RHOXF2	TranscriptionFactor	addTF_JL.tsv
+RHOXF2B	TranscriptionFactor	addTF_JL.tsv
+RICTOR	Oncogene	OncoKBv20240704
+RIGI	TumorSuppressorGene	TumorSuppressorGene.txt
+RINT1	TumorSuppressorGene	TumorSuppressorGene.txt
+RIOK1	Kinase	Kincat_Hsap.08.02.txt
+RIOK2	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704
+RIOK3	Kinase	Kincat_Hsap.08.02.txt
+RIOK3ps	Kinase	Kincat_Hsap.08.02.txt
+RIPK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+RIPK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+RIPK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+RIPK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+RIT1	Oncogene	OncoKBv20240704
+RITA1	TumorSuppressorGene	TumorSuppressorGene.txt
+RLF	TranscriptionFactor	addTF_JL.tsv
+RMI2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RNASEH2A	Oncogene	OncoKBv20240704
+RNASEH2B	TumorSuppressorGene	OncoKBv20240704
+RNASEL	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+RNASET2	TumorSuppressorGene	TumorSuppressorGene.txt
+RNAseL	Kinase	Kincat_Hsap.08.02.txt
+RND3	TumorSuppressorGene	TumorSuppressorGene.txt
+RNF111	TumorSuppressorGene	TumorSuppressorGene.txt
+RNF144A	TumorSuppressorGene	TumorSuppressorGene.txt
+RNF180	TumorSuppressorGene	TumorSuppressorGene.txt
+RNF213	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RNF43	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RNF8	TumorSuppressorGene	TumorSuppressorGene.txt
+RNH1	TumorSuppressorGene	TumorSuppressorGene.txt
+ROBO1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+ROBO2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ROCK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+ROCK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+RON	Kinase	Kincat_Hsap.08.02.txt
+ROR1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+ROR2	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+RORA	TranscriptionFactor	addTF_JL.tsv
+RORB	TranscriptionFactor	addTF_JL.tsv
+RORC	TranscriptionFactor	addTF_JL.tsv
+ROS	Kinase	Kincat_Hsap.08.02.txt
+ROS1	CosmicCensus, Kinase, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+RPA1	TumorSuppressorGene	TumorSuppressorGene.txt
+RPL10	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+RPL11	TumorSuppressorGene	TumorSuppressorGene.txt
+RPL22	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RPL5	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RPN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RPRM	TumorSuppressorGene	TumorSuppressorGene.txt
+RPS15	Oncogene	OncoKBv20240704
+RPS6KA1	Kinase	PfamKinase
+RPS6KA2	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+RPS6KA3	Kinase	PfamKinase
+RPS6KA4	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+RPS6KA5	Kinase	PfamKinase
+RPS6KA6	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+RPS6KB1	Kinase	PfamKinase
+RPS6KB2	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+RPS6KC1	Kinase	PfamKinase
+RPS6KL1	Kinase	PfamKinase
+RPTOR	Oncogene	OncoKBv20240704
+RRAGC	Oncogene	OncoKBv20240704
+RRAS	Oncogene	OncoKBv20240704
+RRAS2	Oncogene	OncoKBv20240704
+RREB1	TranscriptionFactor	addTF_JL.tsv
+RSK1	Kinase	Kincat_Hsap.08.02.txt
+RSK2	Kinase	Kincat_Hsap.08.02.txt
+RSK3	Kinase	Kincat_Hsap.08.02.txt
+RSK4	Kinase	Kincat_Hsap.08.02.txt
+RSKL1	Kinase	Kincat_Hsap.08.02.txt
+RSKL2	Kinase	Kincat_Hsap.08.02.txt
+RSKR	Kinase	PfamKinase
+RSPO2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RSPO3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+RTEL1	TumorSuppressorGene	OncoKBv20240704
+RTN4	TumorSuppressorGene	TumorSuppressorGene.txt
+RTN4IP1	TumorSuppressorGene	TumorSuppressorGene.txt
+RUNX1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+RUNX1T1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+RUNX2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+RUNX3	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+RXRA	TranscriptionFactor	addTF_JL.tsv
+RXRB	TranscriptionFactor	addTF_JL.tsv
+RXRG	TranscriptionFactor	addTF_JL.tsv
+RYBP	TumorSuppressorGene	OncoKBv20240704
+RYK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+RYKps	Kinase	Kincat_Hsap.08.02.txt
+S100A11	TumorSuppressorGene	TumorSuppressorGene.txt
+S100A2	TumorSuppressorGene	TumorSuppressorGene.txt
+S100A7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SAA1	TumorSuppressorGene	TumorSuppressorGene.txt
+SAFB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SAFB2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SAKps	Kinase	Kincat_Hsap.08.02.txt
+SALL1	TranscriptionFactor	addTF_JL.tsv
+SALL2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SALL3	TranscriptionFactor	addTF_JL.tsv
+SALL4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+SAMD9L	TumorSuppressorGene	TumorSuppressorGene.txt
+SAMHD1	TumorSuppressorGene	OncoKBv20240704
+SASH1	TumorSuppressorGene	TumorSuppressorGene.txt
+SATB1	TranscriptionFactor	addTF_JL.tsv
+SATB2	TranscriptionFactor	addTF_JL.tsv
+SBDS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SBK	Kinase	Kincat_Hsap.08.02.txt
+SBK1	Kinase	PfamKinase
+SBK2	Kinase	PfamKinase
+SBK3	Kinase	PfamKinase
+SCAND3	TranscriptionFactor	addTF_JL.tsv
+SCG5	Oncogene	OncoKBv20240704
+SCGB3A1	TumorSuppressorGene	TumorSuppressorGene.txt
+SCMH1	TranscriptionFactor	addTF_JL.tsv
+SCML4	TranscriptionFactor	addTF_JL.tsv
+SCRIB	TumorSuppressorGene	TumorSuppressorGene.txt
+SCRT1	TranscriptionFactor	addTF_JL.tsv
+SCRT2	TranscriptionFactor	addTF_JL.tsv
+SCUBE2	TumorSuppressorGene	TumorSuppressorGene.txt
+SCX	TranscriptionFactor	addTF_JL.tsv
+SCYL1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+SCYL2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SCYL2ps	Kinase	Kincat_Hsap.08.02.txt
+SCYL3	Kinase	Kincat_Hsap.08.02.txt
+SDC4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SDHA	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SDHAF2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SDHB	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SDHC	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SDHD	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SEBOX	TranscriptionFactor	addTF_JL.tsv
+SEC14L2	TumorSuppressorGene	TumorSuppressorGene.txt
+SELENBP1	TumorSuppressorGene	TumorSuppressorGene.txt
+SEMA3B	TumorSuppressorGene	TumorSuppressorGene.txt
+SEMA3F	TumorSuppressorGene	TumorSuppressorGene.txt
+SEPT4	TumorSuppressorGene	TumorSuppressorGene.txt
+SEPT5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SEPT6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SEPT9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SEPTIN4	TumorSuppressorGene	TumorSuppressorGene.txt
+SEPTIN5	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SEPTIN6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SEPTIN9	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SERPINB3	Oncogene, TumorSuppressorGene	OncoKBv20240704
+SERPINB5	TumorSuppressorGene	TumorSuppressorGene.txt
+SERPINI2	TumorSuppressorGene	TumorSuppressorGene.txt
+SESN1	TumorSuppressorGene	OncoKBv20240704
+SESN2	TumorSuppressorGene	OncoKBv20240704
+SESN3	TumorSuppressorGene	OncoKBv20240704
+SET	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SETBP1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+SETD1A	Oncogene	OncoKBv20240704
+SETD1B	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SETD2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SETDB1	CosmicCensus, TranscriptionFactor, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+SETDB2	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+SF3B1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SF3B2	Oncogene	OncoKBv20240704
+SFN	TumorSuppressorGene	TumorSuppressorGene.txt
+SFPQ	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SFRP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+SFRP2	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+SFRP4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+SFRP5	TumorSuppressorGene	TumorSuppressorGene.txt
+SGK1	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+SGK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SGK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SGMS1	TumorSuppressorGene	TumorSuppressorGene.txt
+SGSM2	TranscriptionFactor	addTF_JL.tsv
+SH2B3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SH2D1A	TumorSuppressorGene	OncoKBv20240704
+SH3GL1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SH3GLB1	TumorSuppressorGene	TumorSuppressorGene.txt
+SHISA3	TumorSuppressorGene	TumorSuppressorGene.txt
+SHOC2	Oncogene	OncoKBv20240704
+SHOX	TranscriptionFactor	addTF_JL.tsv
+SHOX2	TranscriptionFactor	addTF_JL.tsv
+SHPRH	TumorSuppressorGene	TumorSuppressorGene.txt
+SHQ1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+SHTN1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SIAH1	TumorSuppressorGene	TumorSuppressorGene.txt
+SIK	Kinase	Kincat_Hsap.08.02.txt
+SIK1	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+SIK1B	Kinase	PfamKinase
+SIK2	Kinase	PfamKinase
+SIK3	Kinase	PfamKinase
+SIM1	TranscriptionFactor	addTF_JL.tsv
+SIM2	TranscriptionFactor	addTF_JL.tsv
+SIRPA	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SIRT1	TumorSuppressorGene	TumorSuppressorGene.txt
+SIRT2	TumorSuppressorGene	TumorSuppressorGene.txt
+SIRT3	TumorSuppressorGene	TumorSuppressorGene.txt
+SIRT4	TumorSuppressorGene	TumorSuppressorGene.txt
+SIRT6	TumorSuppressorGene	TumorSuppressorGene.txt
+SIX1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+SIX2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+SIX3	TranscriptionFactor	addTF_JL.tsv
+SIX4	TranscriptionFactor	addTF_JL.tsv
+SIX5	TranscriptionFactor	addTF_JL.tsv
+SIX6	TranscriptionFactor	addTF_JL.tsv
+SKI	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+SKIL	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SKOR1	TranscriptionFactor	addTF_JL.tsv
+SKOR2	TranscriptionFactor	addTF_JL.tsv
+SKP2	TumorSuppressorGene	TumorSuppressorGene.txt
+SLC2A4RG	TranscriptionFactor	addTF_JL.tsv
+SLC34A2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SLC39A1	TumorSuppressorGene	TumorSuppressorGene.txt
+SLC39A4	TumorSuppressorGene	TumorSuppressorGene.txt
+SLC45A3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SLC5A8	TumorSuppressorGene	TumorSuppressorGene.txt
+SLC9A3R1	TumorSuppressorGene	TumorSuppressorGene.txt
+SLFN11	TumorSuppressorGene	OncoKBv20240704
+SLIT2	TumorSuppressorGene	TumorSuppressorGene.txt
+SLIT3	TumorSuppressorGene	OncoKBv20240704
+SLK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SLX4	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+SMAD1	TranscriptionFactor	addTF_JL.tsv
+SMAD2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SMAD3	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+SMAD4	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+SMAD5	TranscriptionFactor	addTF_JL.tsv
+SMAD9	TranscriptionFactor	addTF_JL.tsv
+SMARCA2	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+SMARCA4	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SMARCB1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SMARCC1	TumorSuppressorGene	TumorSuppressorGene.txt
+SMARCD1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SMARCE1	CosmicCensus, Oncogene, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SMC1A	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SMC3	TumorSuppressorGene	OncoKBv20240704
+SMCHD1	TumorSuppressorGene	TumorSuppressorGene.txt
+SMG1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+SMO	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SMYD3	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+SMYD4	TumorSuppressorGene	TumorSuppressorGene.txt
+SNAI1	TranscriptionFactor	addTF_JL.tsv
+SNAI2	TranscriptionFactor	addTF_JL.tsv
+SNAI3	TranscriptionFactor	addTF_JL.tsv
+SNAPC2	TranscriptionFactor	addTF_JL.tsv
+SNAPC4	TranscriptionFactor	addTF_JL.tsv
+SNAPC5	TranscriptionFactor	addTF_JL.tsv
+SNCAIP	Oncogene	AddedallOnco_Feb2017.tsv
+SND1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SNORD50A	TumorSuppressorGene	TumorSuppressorGene.txt
+SNRK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SNX29	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SOCS1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SOCS3	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+SOD2	TumorSuppressorGene	TumorSuppressorGene.txt
+SOHLH1	TranscriptionFactor	addTF_JL.tsv
+SOHLH2	TranscriptionFactor	addTF_JL.tsv
+SON	TranscriptionFactor	addTF_JL.tsv
+SOS1	Oncogene	OncoKBv20240704
+SOX1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SOX10	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+SOX11	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SOX12	TranscriptionFactor	addTF_JL.tsv
+SOX13	TranscriptionFactor	addTF_JL.tsv
+SOX14	TranscriptionFactor	addTF_JL.tsv
+SOX15	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SOX17	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+SOX18	TranscriptionFactor	addTF_JL.tsv
+SOX2	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+SOX21	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+SOX3	TranscriptionFactor	addTF_JL.tsv
+SOX30	TranscriptionFactor	addTF_JL.tsv
+SOX4	TranscriptionFactor	addTF_JL.tsv
+SOX5	TranscriptionFactor	addTF_JL.tsv
+SOX6	TranscriptionFactor	addTF_JL.tsv
+SOX7	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SOX8	TranscriptionFactor	addTF_JL.tsv
+SOX9	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+SP1	TranscriptionFactor	addTF_JL.tsv
+SP100	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SP110	TranscriptionFactor	addTF_JL.tsv
+SP140	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+SP140L	TranscriptionFactor	addTF_JL.tsv
+SP2	TranscriptionFactor	addTF_JL.tsv
+SP3	TranscriptionFactor	addTF_JL.tsv
+SP4	TranscriptionFactor	addTF_JL.tsv
+SP5	TranscriptionFactor	addTF_JL.tsv
+SP6	TranscriptionFactor	addTF_JL.tsv
+SP7	TranscriptionFactor	addTF_JL.tsv
+SP8	TranscriptionFactor	addTF_JL.tsv
+SP9	TranscriptionFactor	addTF_JL.tsv
+SPARC	TumorSuppressorGene	TumorSuppressorGene.txt
+SPARCL1	TumorSuppressorGene	TumorSuppressorGene.txt
+SPDEF	TranscriptionFactor	addTF_JL.tsv
+SPECC1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SPEG	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SPEN	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+SPI1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+SPIB	TranscriptionFactor	addTF_JL.tsv
+SPIC	TranscriptionFactor	addTF_JL.tsv
+SPINK7	TumorSuppressorGene	TumorSuppressorGene.txt
+SPINT2	TumorSuppressorGene	TumorSuppressorGene.txt
+SPOP	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SPRED1	TumorSuppressorGene	OncoKBv20240704
+SPRTN	TumorSuppressorGene	OncoKBv20240704
+SPRY2	TumorSuppressorGene	TumorSuppressorGene.txt
+SPRY4	TumorSuppressorGene	TumorSuppressorGene.txt
+SPTBN1	TumorSuppressorGene	TumorSuppressorGene.txt
+SPZ1	TranscriptionFactor	addTF_JL.tsv
+SQSTM1	Oncogene	OncoKBv20240704
+SRC	Kinase, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+SRCAP	TranscriptionFactor	addTF_JL.tsv
+SREBF1	TranscriptionFactor	addTF_JL.tsv
+SREBF2	TranscriptionFactor	addTF_JL.tsv
+SRF	TranscriptionFactor	addTF_JL.tsv
+SRGAP3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+SRM	Kinase	Kincat_Hsap.08.02.txt
+SRMS	Kinase	PfamKinase
+SRP72	Oncogene	OncoKBv20240704
+SRPK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SRPK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+SRPK2ps	Kinase	Kincat_Hsap.08.02.txt
+SRPK3	Kinase	PfamKinase
+SRPX	TumorSuppressorGene	TumorSuppressorGene.txt
+SRSF2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SRSF3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SRY	TranscriptionFactor	addTF_JL.tsv
+SS18	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SS18L1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SSBP2	TumorSuppressorGene	TumorSuppressorGene.txt
+SSTK	Kinase	Kincat_Hsap.08.02.txt
+SSX1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SSX2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+SSX4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ST13	TumorSuppressorGene	TumorSuppressorGene.txt
+ST18	TranscriptionFactor	addTF_JL.tsv
+ST20	TumorSuppressorGene	TumorSuppressorGene.txt
+ST5	TumorSuppressorGene	TumorSuppressorGene.txt
+ST7	TumorSuppressorGene	TumorSuppressorGene.txt
+STAG1	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+STAG2	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+STARD13	TumorSuppressorGene	TumorSuppressorGene.txt
+STAT1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+STAT2	TranscriptionFactor	addTF_JL.tsv
+STAT3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+STAT4	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+STAT5A	TumorSuppressorGene, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704
+STAT5B	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+STAT6	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+STIL	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+STK10	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+STK11	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+STK16	Kinase	PfamKinase
+STK17A	Kinase	PfamKinase
+STK17B	Kinase	PfamKinase
+STK19	Oncogene	OncoKBv20240704
+STK24	Kinase	PfamKinase
+STK25	Kinase	PfamKinase
+STK26	Kinase	PfamKinase
+STK3	Kinase	PfamKinase
+STK31	Kinase	PfamKinase
+STK32A	Kinase	PfamKinase
+STK32B	Kinase	PfamKinase
+STK32C	Kinase	PfamKinase
+STK33	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+STK33ps	Kinase	Kincat_Hsap.08.02.txt
+STK35	Kinase	PfamKinase
+STK36	Kinase	PfamKinase
+STK38	Kinase	PfamKinase
+STK38L	Kinase	PfamKinase
+STK39	Kinase	PfamKinase
+STK4	Kinase	PfamKinase
+STK40	Kinase	PfamKinase
+STKLD1	Kinase	PfamKinase
+STLK3	Kinase	Kincat_Hsap.08.02.txt
+STLK5	Kinase	Kincat_Hsap.08.02.txt
+STLK6	Kinase	Kincat_Hsap.08.02.txt
+STLK6-rs	Kinase	Kincat_Hsap.08.02.txt
+STLK6ps1	Kinase	Kincat_Hsap.08.02.txt
+STRADA	TumorSuppressorGene, Kinase	TumorSuppressorGene.txt, PfamKinase
+STRADB	Kinase	PfamKinase
+STRN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+STUB1	TumorSuppressorGene	TumorSuppressorGene.txt
+STYK1	Kinase	PfamKinase
+SUFU	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SUZ12	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+SYK	Kinase, TumorSuppressorGene, CosmicCensus, Oncogene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+SYNM	TumorSuppressorGene	TumorSuppressorGene.txt
+SYNPO2	TumorSuppressorGene	TumorSuppressorGene.txt
+SYT13	TumorSuppressorGene	TumorSuppressorGene.txt
+SgK050ps	Kinase	Kincat_Hsap.08.02.txt
+SgK069	Kinase	Kincat_Hsap.08.02.txt
+SgK071	Kinase	Kincat_Hsap.08.02.txt
+SgK085	Kinase	Kincat_Hsap.08.02.txt
+SgK110	Kinase	Kincat_Hsap.08.02.txt
+SgK196	Kinase	Kincat_Hsap.08.02.txt
+SgK223	Kinase	Kincat_Hsap.08.02.txt
+SgK269	Kinase	Kincat_Hsap.08.02.txt
+SgK288	Kinase	Kincat_Hsap.08.02.txt
+SgK307	Kinase	Kincat_Hsap.08.02.txt
+SgK384ps	Kinase	Kincat_Hsap.08.02.txt
+SgK396	Kinase	Kincat_Hsap.08.02.txt
+SgK424	Kinase	Kincat_Hsap.08.02.txt
+SgK493	Kinase	Kincat_Hsap.08.02.txt
+SgK494	Kinase	Kincat_Hsap.08.02.txt
+SgK495	Kinase	Kincat_Hsap.08.02.txt
+SgK496	Kinase	Kincat_Hsap.08.02.txt
+Slob	Kinase	Kincat_Hsap.08.02.txt
+SuRTK106	Kinase	Kincat_Hsap.08.02.txt
+T	TranscriptionFactor	addTF_JL.tsv
+TAF1	Kinase, Oncogene	Kincat_Hsap.08.02.txt, OncoKBv20240704
+TAF15	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TAF1L	Kinase	Kincat_Hsap.08.02.txt
+TAGLN	TumorSuppressorGene	TumorSuppressorGene.txt
+TAK1	Kinase	Kincat_Hsap.08.02.txt
+TAL1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TAL2	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+TANK	TumorSuppressorGene	TumorSuppressorGene.txt
+TAO1	Kinase	Kincat_Hsap.08.02.txt
+TAO2	Kinase	Kincat_Hsap.08.02.txt
+TAO3	Kinase	Kincat_Hsap.08.02.txt
+TAOK1	Kinase	PfamKinase
+TAOK2	Kinase	PfamKinase
+TAOK3	Kinase	PfamKinase
+TAT	TumorSuppressorGene	TumorSuppressorGene.txt
+TBCK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TBK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TBL1XR1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TBL2	TumorSuppressorGene	TumorSuppressorGene.txt
+TBP	TranscriptionFactor	addTF_JL.tsv
+TBPL1	TranscriptionFactor	addTF_JL.tsv
+TBPL2	TranscriptionFactor	addTF_JL.tsv
+TBR1	TranscriptionFactor	addTF_JL.tsv
+TBRG1	TumorSuppressorGene	TumorSuppressorGene.txt
+TBX1	TranscriptionFactor	addTF_JL.tsv
+TBX10	TranscriptionFactor	addTF_JL.tsv
+TBX15	TranscriptionFactor	addTF_JL.tsv
+TBX18	TranscriptionFactor	addTF_JL.tsv
+TBX19	TranscriptionFactor	addTF_JL.tsv
+TBX2	TranscriptionFactor	addTF_JL.tsv
+TBX20	TranscriptionFactor	addTF_JL.tsv
+TBX21	TranscriptionFactor	addTF_JL.tsv
+TBX22	TranscriptionFactor	addTF_JL.tsv
+TBX3	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TBX4	TranscriptionFactor	addTF_JL.tsv
+TBX5	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TBX6	TranscriptionFactor	addTF_JL.tsv
+TBXT	TranscriptionFactor	addTF_JL.tsv
+TCEA1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TCEAL7	TumorSuppressorGene	TumorSuppressorGene.txt
+TCEB3	TumorSuppressorGene	TumorSuppressorGene.txt
+TCF12	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+TCF15	TranscriptionFactor	addTF_JL.tsv
+TCF20	TranscriptionFactor	addTF_JL.tsv
+TCF21	TranscriptionFactor	addTF_JL.tsv
+TCF23	TranscriptionFactor	addTF_JL.tsv
+TCF24	TranscriptionFactor	addTF_JL.tsv
+TCF3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TCF4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TCF7	TranscriptionFactor	addTF_JL.tsv
+TCF7L1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+TCF7L2	TumorSuppressorGene, TranscriptionFactor, CosmicCensus	TumorSuppressorGene.txt, addTF_JL.tsv, OncoKBv20240704, Census_allTue Sep 17 18_59_30 2019.tsv
+TCFL5	TranscriptionFactor	addTF_JL.tsv
+TCHP	TumorSuppressorGene	TumorSuppressorGene.txt
+TCL1A	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TCL1B	Oncogene	OncoKBv20240704
+TDGF1	TumorSuppressorGene	TumorSuppressorGene.txt
+TDRG1	TumorSuppressorGene	TumorSuppressorGene.txt
+TEAD1	TranscriptionFactor	addTF_JL.tsv
+TEAD2	TranscriptionFactor	addTF_JL.tsv
+TEAD3	TranscriptionFactor	addTF_JL.tsv
+TEAD4	TranscriptionFactor	addTF_JL.tsv
+TEC	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+TEF	TranscriptionFactor	addTF_JL.tsv
+TEK	Kinase	PfamKinase
+TENT5C	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TERB1	TranscriptionFactor	addTF_JL.tsv
+TERF1	TranscriptionFactor	addTF_JL.tsv
+TERF2	TranscriptionFactor	addTF_JL.tsv
+TERT	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, AddedallOnco_Feb2017.tsv, OncoKBv20240704
+TES	TumorSuppressorGene	TumorSuppressorGene.txt
+TESK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TESK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TET1	CosmicCensus, TranscriptionFactor, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TET2	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TET3	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+TEX14	Kinase	PfamKinase
+TFAP2A	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TFAP2B	TranscriptionFactor	addTF_JL.tsv
+TFAP2C	TranscriptionFactor	addTF_JL.tsv
+TFAP2D	TranscriptionFactor	addTF_JL.tsv
+TFAP2E	TranscriptionFactor	addTF_JL.tsv
+TFAP4	TranscriptionFactor	addTF_JL.tsv
+TFCP2	TranscriptionFactor	addTF_JL.tsv
+TFCP2L1	TranscriptionFactor	addTF_JL.tsv
+TFDP1	TranscriptionFactor	addTF_JL.tsv
+TFDP2	TranscriptionFactor	addTF_JL.tsv
+TFDP3	TranscriptionFactor	addTF_JL.tsv
+TFE3	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TFEB	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+TFEC	TranscriptionFactor	addTF_JL.tsv
+TFG	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TFPI2	TumorSuppressorGene	TumorSuppressorGene.txt
+TFPT	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TFRC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TGFB1	TumorSuppressorGene	TumorSuppressorGene.txt
+TGFBI	TumorSuppressorGene	TumorSuppressorGene.txt
+TGFBR1	Kinase, TumorSuppressorGene	PfamKinase, OncoKBv20240704
+TGFBR2	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase, OncoKBv20240704
+TGFBR3	TumorSuppressorGene	TumorSuppressorGene.txt
+TGFbR1	Kinase	Kincat_Hsap.08.02.txt
+TGFbR2	Kinase	Kincat_Hsap.08.02.txt
+TGIF1	TranscriptionFactor	addTF_JL.tsv
+TGIF2	TranscriptionFactor	addTF_JL.tsv
+TGIF2LX	TranscriptionFactor	addTF_JL.tsv
+TGIF2LY	TranscriptionFactor	addTF_JL.tsv
+TGM3	TumorSuppressorGene	TumorSuppressorGene.txt
+THAP1	TranscriptionFactor	addTF_JL.tsv
+THAP10	TranscriptionFactor	addTF_JL.tsv
+THAP11	TranscriptionFactor	addTF_JL.tsv
+THAP12	TranscriptionFactor	addTF_JL.tsv
+THAP2	TranscriptionFactor	addTF_JL.tsv
+THAP3	TranscriptionFactor	addTF_JL.tsv
+THAP4	TranscriptionFactor	addTF_JL.tsv
+THAP5	TranscriptionFactor	addTF_JL.tsv
+THAP6	TranscriptionFactor	addTF_JL.tsv
+THAP7	TranscriptionFactor	addTF_JL.tsv
+THAP8	TranscriptionFactor	addTF_JL.tsv
+THAP9	TranscriptionFactor	addTF_JL.tsv
+THBD	TumorSuppressorGene	TumorSuppressorGene.txt
+THBS1	TumorSuppressorGene	TumorSuppressorGene.txt
+THRA	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+THRAP3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+THRB	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+THSD1	TumorSuppressorGene	TumorSuppressorGene.txt
+THY1	TumorSuppressorGene	TumorSuppressorGene.txt
+THYN1	TranscriptionFactor	addTF_JL.tsv
+TIE1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TIE2	Kinase	Kincat_Hsap.08.02.txt
+TIF1a	Kinase	Kincat_Hsap.08.02.txt
+TIF1b	Kinase	Kincat_Hsap.08.02.txt
+TIF1g	Kinase	Kincat_Hsap.08.02.txt
+TIGAR	Oncogene	OncoKBv20240704
+TIGD1	TranscriptionFactor	addTF_JL.tsv
+TIGD2	TranscriptionFactor	addTF_JL.tsv
+TIGD3	TranscriptionFactor	addTF_JL.tsv
+TIGD4	TranscriptionFactor	addTF_JL.tsv
+TIGD5	TranscriptionFactor	addTF_JL.tsv
+TIGD6	TranscriptionFactor	addTF_JL.tsv
+TIGD7	TranscriptionFactor	addTF_JL.tsv
+TIMP3	TumorSuppressorGene	TumorSuppressorGene.txt
+TLK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TLK1ps	Kinase	Kincat_Hsap.08.02.txt
+TLK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TLK2ps1	Kinase	Kincat_Hsap.08.02.txt
+TLK2ps2	Kinase	Kincat_Hsap.08.02.txt
+TLX1	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TLX2	TranscriptionFactor	addTF_JL.tsv
+TLX3	CosmicCensus, TranscriptionFactor, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TMEFF1	TumorSuppressorGene	TumorSuppressorGene.txt
+TMEFF2	TumorSuppressorGene	TumorSuppressorGene.txt
+TMEM127	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TMF1	TranscriptionFactor	addTF_JL.tsv
+TMPRSS11A	TumorSuppressorGene	TumorSuppressorGene.txt
+TMPRSS2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TMPRSS6	TumorSuppressorGene	TumorSuppressorGene.txt
+TNC	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TNFAIP3	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TNFAIP8L2	TumorSuppressorGene	TumorSuppressorGene.txt
+TNFRSF10A	TumorSuppressorGene	TumorSuppressorGene.txt
+TNFRSF10B	TumorSuppressorGene	TumorSuppressorGene.txt
+TNFRSF12A	TumorSuppressorGene	TumorSuppressorGene.txt
+TNFRSF14	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TNFRSF17	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TNFRSF18	TumorSuppressorGene	TumorSuppressorGene.txt
+TNFSF12	TumorSuppressorGene	TumorSuppressorGene.txt
+TNFSF13	Oncogene	OncoKBv20240704
+TNFSF9	TumorSuppressorGene	TumorSuppressorGene.txt
+TNIK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TNK1	Kinase, TumorSuppressorGene	Kincat_Hsap.08.02.txt, TumorSuppressorGene.txt, PfamKinase
+TNK2	Kinase	PfamKinase
+TNNI3K	Kinase	PfamKinase
+TOM1L2	TumorSuppressorGene	TumorSuppressorGene.txt
+TOP1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TOP2A	Oncogene	OncoKBv20240704
+TOPORS	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TP53	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TP53BP1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+TP53BP2	TumorSuppressorGene	TumorSuppressorGene.txt
+TP53COR1	TumorSuppressorGene	TumorSuppressorGene.txt
+TP53INP1	TumorSuppressorGene	TumorSuppressorGene.txt
+TP63	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+TP73	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TPM3	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TPM4	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TPR	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TPRX1	TranscriptionFactor	addTF_JL.tsv
+TPTE2	TumorSuppressorGene	TumorSuppressorGene.txt
+TPTEP2-CSNK1E	Kinase	PfamKinase
+TRA	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TRAF3	TumorSuppressorGene	OncoKBv20240704
+TRAF5	TumorSuppressorGene	OncoKBv20240704
+TRAF7	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TRAFD1	TranscriptionFactor	addTF_JL.tsv
+TRB	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TRD	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TRD-GTC9-1	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TRERF1	TranscriptionFactor	addTF_JL.tsv
+TREX2	TumorSuppressorGene	TumorSuppressorGene.txt
+TRG	Oncogene	OncoKBv20240704
+TRIB1	Kinase	PfamKinase
+TRIB2	Kinase	PfamKinase
+TRIB3	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+TRIM13	TumorSuppressorGene	TumorSuppressorGene.txt
+TRIM15	TumorSuppressorGene	TumorSuppressorGene.txt
+TRIM24	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv
+TRIM27	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TRIM3	TumorSuppressorGene	TumorSuppressorGene.txt
+TRIM31	TumorSuppressorGene	TumorSuppressorGene.txt
+TRIM32	TumorSuppressorGene	TumorSuppressorGene.txt
+TRIM33	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TRIM35	TumorSuppressorGene	TumorSuppressorGene.txt
+TRIM62	TumorSuppressorGene	TumorSuppressorGene.txt
+TRIO	Kinase	PfamKinase
+TRIP11	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+TRIP13	Oncogene, TumorSuppressorGene	OncoKBv20240704
+TRIT1	TumorSuppressorGene	TumorSuppressorGene.txt
+TRKA	Kinase	Kincat_Hsap.08.02.txt
+TRKB	Kinase	Kincat_Hsap.08.02.txt
+TRKC	Kinase	Kincat_Hsap.08.02.txt
+TRPM6	Kinase	PfamKinase
+TRPM7	Kinase	PfamKinase
+TRPS1	TranscriptionFactor	addTF_JL.tsv
+TRRAP	Kinase, CosmicCensus	Kincat_Hsap.08.02.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+TSC1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TSC2	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TSC22D1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TSG101	TumorSuppressorGene	TumorSuppressorGene.txt
+TSHR	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+TSHZ1	TranscriptionFactor	addTF_JL.tsv
+TSHZ2	TranscriptionFactor	addTF_JL.tsv
+TSHZ3	TranscriptionFactor	addTF_JL.tsv
+TSLP	TumorSuppressorGene	TumorSuppressorGene.txt
+TSPAN13	TumorSuppressorGene	TumorSuppressorGene.txt
+TSPAN32	TumorSuppressorGene	TumorSuppressorGene.txt
+TSSC4	TumorSuppressorGene	TumorSuppressorGene.txt
+TSSK1	Kinase	Kincat_Hsap.08.02.txt
+TSSK1B	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TSSK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TSSK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TSSK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TSSK6	Kinase	PfamKinase
+TSSKps1	Kinase	Kincat_Hsap.08.02.txt
+TSSKps2	Kinase	Kincat_Hsap.08.02.txt
+TTBK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TTBK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TTC4	TumorSuppressorGene	TumorSuppressorGene.txt
+TTF1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TTK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TTN	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TTYH1	Oncogene	AddedallOnco_Feb2017.tsv
+TUSC1	TumorSuppressorGene	TumorSuppressorGene.txt
+TUSC2	TumorSuppressorGene	TumorSuppressorGene.txt
+TUSC7	TumorSuppressorGene	TumorSuppressorGene.txt
+TWIST1	TranscriptionFactor	addTF_JL.tsv
+TWIST2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+TXK	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TXNIP	TumorSuppressorGene	TumorSuppressorGene.txt
+TYK2	Kinase, Oncogene	Kincat_Hsap.08.02.txt, PfamKinase, OncoKBv20240704
+TYRO3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+TYRO3ps	Kinase	Kincat_Hsap.08.02.txt
+Trad	Kinase	Kincat_Hsap.08.02.txt
+Trb1	Kinase	Kincat_Hsap.08.02.txt
+Trb2	Kinase	Kincat_Hsap.08.02.txt
+Trb3	Kinase	Kincat_Hsap.08.02.txt
+Trio	Kinase	Kincat_Hsap.08.02.txt
+U2AF1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+UBA1	Oncogene	OncoKBv20240704
+UBE2A	Oncogene	OncoKBv20240704
+UBE2QL1	TumorSuppressorGene	TumorSuppressorGene.txt
+UBE4B	TumorSuppressorGene	TumorSuppressorGene.txt
+UBIAD1	TumorSuppressorGene	TumorSuppressorGene.txt
+UBP1	TranscriptionFactor	addTF_JL.tsv
+UBR5	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+UBTF	Oncogene	OncoKBv20240704
+UCHL1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+UFL1	TumorSuppressorGene	TumorSuppressorGene.txt
+UHMK1	Kinase	PfamKinase
+UHRF2	TumorSuppressorGene	TumorSuppressorGene.txt
+UIMC1	TumorSuppressorGene	TumorSuppressorGene.txt
+ULK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+ULK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+ULK3	Kinase	Kincat_Hsap.08.02.txt
+ULK4	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+UNC5A	TumorSuppressorGene	TumorSuppressorGene.txt
+UNC5B	TumorSuppressorGene	TumorSuppressorGene.txt
+UNC5C	TumorSuppressorGene	TumorSuppressorGene.txt
+UNC5D	TumorSuppressorGene	TumorSuppressorGene.txt
+UNCX	TranscriptionFactor	addTF_JL.tsv
+USF1	TranscriptionFactor	addTF_JL.tsv
+USF2	TranscriptionFactor	addTF_JL.tsv
+USF3	TranscriptionFactor	addTF_JL.tsv
+USP12	TumorSuppressorGene	TumorSuppressorGene.txt
+USP12P1	TumorSuppressorGene	TumorSuppressorGene.txt
+USP33	TumorSuppressorGene	TumorSuppressorGene.txt
+USP44	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+USP6	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+USP8	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+UVRAG	TumorSuppressorGene	TumorSuppressorGene.txt
+VACAMKL	Kinase	Kincat_Hsap.08.02.txt
+VAV1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+VAV2	Oncogene	OncoKBv20240704
+VAX1	TranscriptionFactor	addTF_JL.tsv
+VAX2	TranscriptionFactor	addTF_JL.tsv
+VDR	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+VEGFA	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+VENTX	TranscriptionFactor	addTF_JL.tsv
+VEZF1	TranscriptionFactor	addTF_JL.tsv
+VEZT	TumorSuppressorGene	TumorSuppressorGene.txt
+VHL	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+VIL1	TumorSuppressorGene	TumorSuppressorGene.txt
+VIM	TumorSuppressorGene	TumorSuppressorGene.txt
+VPS53	TumorSuppressorGene	TumorSuppressorGene.txt
+VRK1	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+VRK2	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+VRK3	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+VRK3ps	Kinase	Kincat_Hsap.08.02.txt
+VSNL1	TumorSuppressorGene	TumorSuppressorGene.txt
+VSX1	TranscriptionFactor	addTF_JL.tsv
+VSX2	TranscriptionFactor	addTF_JL.tsv
+VTI1A	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+VTRNA2-1	TumorSuppressorGene	TumorSuppressorGene.txt
+VWA5A	TumorSuppressorGene	TumorSuppressorGene.txt
+WAS	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+WDCP	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+WDR11	TumorSuppressorGene	TumorSuppressorGene.txt
+WDR48	TumorSuppressorGene	TumorSuppressorGene.txt
+WEE1	Kinase	PfamKinase
+WEE2	Kinase	PfamKinase
+WFDC1	TumorSuppressorGene	TumorSuppressorGene.txt
+WHSC1L1	TumorSuppressorGene	TumorSuppressorGene.txt
+WIF1	TumorSuppressorGene, CosmicCensus	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+WISP3	TumorSuppressorGene	TumorSuppressorGene.txt
+WIZ	TranscriptionFactor	addTF_JL.tsv
+WNK1	Kinase	PfamKinase
+WNK2	TumorSuppressorGene, CosmicCensus, Kinase	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, PfamKinase
+WNK3	Kinase	PfamKinase
+WNK4	Kinase	PfamKinase
+WNT11	TumorSuppressorGene	TumorSuppressorGene.txt
+WNT5A	TumorSuppressorGene	TumorSuppressorGene.txt
+WNT7A	TumorSuppressorGene	TumorSuppressorGene.txt
+WRN	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+WT1	TumorSuppressorGene, CosmicCensus, TranscriptionFactor, Oncogene	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+WWOX	TumorSuppressorGene	TumorSuppressorGene.txt
+WWP1	Oncogene	OncoKBv20240704
+WWTR1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+Wee1	Kinase	Kincat_Hsap.08.02.txt
+Wee1B	Kinase	Kincat_Hsap.08.02.txt
+Wee1Bps	Kinase	Kincat_Hsap.08.02.txt
+Wee1ps1	Kinase	Kincat_Hsap.08.02.txt
+Wee1ps2	Kinase	Kincat_Hsap.08.02.txt
+Wnk1	Kinase	Kincat_Hsap.08.02.txt
+Wnk2	Kinase	Kincat_Hsap.08.02.txt
+Wnk3	Kinase	Kincat_Hsap.08.02.txt
+Wnk4	Kinase	Kincat_Hsap.08.02.txt
+XAF1	TumorSuppressorGene	TumorSuppressorGene.txt
+XBP1	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+XBP1P1	TranscriptionFactor	addTF_JL.tsv
+XIAP	Oncogene	OncoKBv20240704
+XIST	TumorSuppressorGene	TumorSuppressorGene.txt
+XPA	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+XPC	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+XPO1	CosmicCensus, Oncogene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+XPO5	TumorSuppressorGene	TumorSuppressorGene.txt
+XRCC1	TumorSuppressorGene	OncoKBv20240704
+XRCC2	TumorSuppressorGene	OncoKBv20240704
+XRCC5	TumorSuppressorGene	TumorSuppressorGene.txt
+YANK1	Kinase	Kincat_Hsap.08.02.txt
+YANK2	Kinase	Kincat_Hsap.08.02.txt
+YANK3	Kinase	Kincat_Hsap.08.02.txt
+YAP1	TumorSuppressorGene, Oncogene	TumorSuppressorGene.txt, OncoKBv20240704
+YBX1	TranscriptionFactor	addTF_JL.tsv
+YBX2	TranscriptionFactor	addTF_JL.tsv
+YBX3	TranscriptionFactor	addTF_JL.tsv
+YES	Kinase	Kincat_Hsap.08.02.txt
+YES1	Kinase, Oncogene	PfamKinase, OncoKBv20240704
+YESps	Kinase	Kincat_Hsap.08.02.txt
+YPEL3	TumorSuppressorGene	TumorSuppressorGene.txt
+YSK1	Kinase	Kincat_Hsap.08.02.txt
+YWHAE	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+YY1	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+YY2	TranscriptionFactor	addTF_JL.tsv
+ZAK	Kinase	Kincat_Hsap.08.02.txt
+ZAP70	Kinase	Kincat_Hsap.08.02.txt, PfamKinase
+ZBED1	TranscriptionFactor	addTF_JL.tsv
+ZBED2	TranscriptionFactor	addTF_JL.tsv
+ZBED3	TranscriptionFactor	addTF_JL.tsv
+ZBED4	TranscriptionFactor	addTF_JL.tsv
+ZBED5	TranscriptionFactor	addTF_JL.tsv
+ZBED6	TranscriptionFactor	addTF_JL.tsv
+ZBED9	TranscriptionFactor	addTF_JL.tsv
+ZBTB1	TranscriptionFactor	addTF_JL.tsv
+ZBTB10	TranscriptionFactor	addTF_JL.tsv
+ZBTB11	TranscriptionFactor	addTF_JL.tsv
+ZBTB12	TranscriptionFactor	addTF_JL.tsv
+ZBTB14	TranscriptionFactor	addTF_JL.tsv
+ZBTB16	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ZBTB17	TranscriptionFactor	addTF_JL.tsv
+ZBTB18	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZBTB2	TranscriptionFactor	addTF_JL.tsv
+ZBTB20	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+ZBTB21	TranscriptionFactor	addTF_JL.tsv
+ZBTB22	TranscriptionFactor	addTF_JL.tsv
+ZBTB24	TranscriptionFactor	addTF_JL.tsv
+ZBTB25	TranscriptionFactor	addTF_JL.tsv
+ZBTB26	TranscriptionFactor	addTF_JL.tsv
+ZBTB3	TranscriptionFactor	addTF_JL.tsv
+ZBTB32	TranscriptionFactor	addTF_JL.tsv
+ZBTB33	TranscriptionFactor	addTF_JL.tsv
+ZBTB34	TranscriptionFactor	addTF_JL.tsv
+ZBTB37	TranscriptionFactor	addTF_JL.tsv
+ZBTB38	TranscriptionFactor	addTF_JL.tsv
+ZBTB39	TranscriptionFactor	addTF_JL.tsv
+ZBTB4	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZBTB40	TranscriptionFactor	addTF_JL.tsv
+ZBTB41	TranscriptionFactor	addTF_JL.tsv
+ZBTB42	TranscriptionFactor	addTF_JL.tsv
+ZBTB43	TranscriptionFactor	addTF_JL.tsv
+ZBTB44	TranscriptionFactor	addTF_JL.tsv
+ZBTB45	TranscriptionFactor	addTF_JL.tsv
+ZBTB46	TranscriptionFactor	addTF_JL.tsv
+ZBTB47	TranscriptionFactor	addTF_JL.tsv
+ZBTB48	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZBTB49	TranscriptionFactor	addTF_JL.tsv
+ZBTB5	TranscriptionFactor	addTF_JL.tsv
+ZBTB6	TranscriptionFactor	addTF_JL.tsv
+ZBTB7A	TranscriptionFactor, Oncogene, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+ZBTB7B	TranscriptionFactor	addTF_JL.tsv
+ZBTB7C	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZBTB8A	TranscriptionFactor	addTF_JL.tsv
+ZBTB8B	TranscriptionFactor	addTF_JL.tsv
+ZBTB9	TranscriptionFactor	addTF_JL.tsv
+ZC3H10	TumorSuppressorGene	TumorSuppressorGene.txt
+ZC3H8	TranscriptionFactor	addTF_JL.tsv
+ZCCHC8	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ZDHHC2	TumorSuppressorGene	TumorSuppressorGene.txt
+ZEB1	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ZEB2	TranscriptionFactor	addTF_JL.tsv
+ZFAS1	TumorSuppressorGene	TumorSuppressorGene.txt
+ZFAT	TranscriptionFactor	addTF_JL.tsv
+ZFHX2	TranscriptionFactor	addTF_JL.tsv
+ZFHX3	TumorSuppressorGene, CosmicCensus, TranscriptionFactor	TumorSuppressorGene.txt, Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv, OncoKBv20240704
+ZFHX4	TranscriptionFactor	addTF_JL.tsv
+ZFP1	TranscriptionFactor	addTF_JL.tsv
+ZFP14	TranscriptionFactor	addTF_JL.tsv
+ZFP2	TranscriptionFactor	addTF_JL.tsv
+ZFP28	TranscriptionFactor	addTF_JL.tsv
+ZFP3	TranscriptionFactor	addTF_JL.tsv
+ZFP30	TranscriptionFactor	addTF_JL.tsv
+ZFP36	TumorSuppressorGene	TumorSuppressorGene.txt
+ZFP36L1	TumorSuppressorGene	TumorSuppressorGene.txt, OncoKBv20240704
+ZFP36L2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, OncoKBv20240704, addTF_JL.tsv
+ZFP37	TranscriptionFactor	addTF_JL.tsv
+ZFP41	TranscriptionFactor	addTF_JL.tsv
+ZFP42	TranscriptionFactor	addTF_JL.tsv
+ZFP57	TranscriptionFactor	addTF_JL.tsv
+ZFP62	TranscriptionFactor	addTF_JL.tsv
+ZFP64	TranscriptionFactor	addTF_JL.tsv
+ZFP69	TranscriptionFactor	addTF_JL.tsv
+ZFP69B	TranscriptionFactor	addTF_JL.tsv
+ZFP82	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZFP90	TranscriptionFactor	addTF_JL.tsv
+ZFP91	TranscriptionFactor	addTF_JL.tsv
+ZFP92	TranscriptionFactor	addTF_JL.tsv
+ZFPM1	TranscriptionFactor	addTF_JL.tsv
+ZFPM2	TranscriptionFactor	addTF_JL.tsv
+ZFTA	TranscriptionFactor	addTF_JL.tsv
+ZFX	TranscriptionFactor	addTF_JL.tsv
+ZFY	TranscriptionFactor	addTF_JL.tsv
+ZGLP1	TranscriptionFactor	addTF_JL.tsv
+ZGPAT	TranscriptionFactor	addTF_JL.tsv
+ZHX1	TranscriptionFactor	addTF_JL.tsv
+ZHX2	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZHX3	TranscriptionFactor	addTF_JL.tsv
+ZIC1	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZIC2	TranscriptionFactor	addTF_JL.tsv
+ZIC3	TranscriptionFactor	addTF_JL.tsv
+ZIC4	TranscriptionFactor	addTF_JL.tsv
+ZIC5	TranscriptionFactor	addTF_JL.tsv
+ZIK1	TranscriptionFactor	addTF_JL.tsv
+ZIM2	TranscriptionFactor	addTF_JL.tsv
+ZIM3	TranscriptionFactor	addTF_JL.tsv
+ZKSCAN1	TranscriptionFactor	addTF_JL.tsv
+ZKSCAN2	TranscriptionFactor	addTF_JL.tsv
+ZKSCAN3	TranscriptionFactor	addTF_JL.tsv
+ZKSCAN4	TranscriptionFactor	addTF_JL.tsv
+ZKSCAN5	TranscriptionFactor	addTF_JL.tsv
+ZKSCAN7	TranscriptionFactor	addTF_JL.tsv
+ZKSCAN8	TranscriptionFactor	addTF_JL.tsv
+ZMAT1	TranscriptionFactor	addTF_JL.tsv
+ZMAT4	TranscriptionFactor	addTF_JL.tsv
+ZMYM2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ZMYM3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ZMYND10	TumorSuppressorGene	TumorSuppressorGene.txt
+ZMYND11	TumorSuppressorGene	TumorSuppressorGene.txt
+ZNF10	TranscriptionFactor	addTF_JL.tsv
+ZNF100	TranscriptionFactor	addTF_JL.tsv
+ZNF101	TranscriptionFactor	addTF_JL.tsv
+ZNF107	TranscriptionFactor	addTF_JL.tsv
+ZNF112	TranscriptionFactor	addTF_JL.tsv
+ZNF114	TranscriptionFactor	addTF_JL.tsv
+ZNF117	TranscriptionFactor	addTF_JL.tsv
+ZNF12	TranscriptionFactor	addTF_JL.tsv
+ZNF121	TranscriptionFactor	addTF_JL.tsv
+ZNF124	TranscriptionFactor	addTF_JL.tsv
+ZNF131	TranscriptionFactor	addTF_JL.tsv
+ZNF132	TranscriptionFactor	addTF_JL.tsv
+ZNF133	TranscriptionFactor	addTF_JL.tsv
+ZNF134	TranscriptionFactor	addTF_JL.tsv
+ZNF135	TranscriptionFactor	addTF_JL.tsv
+ZNF136	TranscriptionFactor	addTF_JL.tsv
+ZNF138	TranscriptionFactor	addTF_JL.tsv
+ZNF14	TranscriptionFactor	addTF_JL.tsv
+ZNF140	TranscriptionFactor	addTF_JL.tsv
+ZNF141	TranscriptionFactor	addTF_JL.tsv
+ZNF142	TranscriptionFactor	addTF_JL.tsv
+ZNF143	TranscriptionFactor	addTF_JL.tsv
+ZNF146	TranscriptionFactor	addTF_JL.tsv
+ZNF148	TranscriptionFactor	addTF_JL.tsv
+ZNF154	TranscriptionFactor	addTF_JL.tsv
+ZNF155	TranscriptionFactor	addTF_JL.tsv
+ZNF157	TranscriptionFactor	addTF_JL.tsv
+ZNF16	TranscriptionFactor	addTF_JL.tsv
+ZNF160	TranscriptionFactor	addTF_JL.tsv
+ZNF165	TranscriptionFactor	addTF_JL.tsv
+ZNF169	TranscriptionFactor	addTF_JL.tsv
+ZNF17	TranscriptionFactor	addTF_JL.tsv
+ZNF174	TranscriptionFactor	addTF_JL.tsv
+ZNF175	TranscriptionFactor	addTF_JL.tsv
+ZNF177	TranscriptionFactor	addTF_JL.tsv
+ZNF18	TranscriptionFactor	addTF_JL.tsv
+ZNF180	TranscriptionFactor	addTF_JL.tsv
+ZNF181	TranscriptionFactor	addTF_JL.tsv
+ZNF182	TranscriptionFactor	addTF_JL.tsv
+ZNF184	TranscriptionFactor	addTF_JL.tsv
+ZNF185	TumorSuppressorGene	TumorSuppressorGene.txt
+ZNF189	TranscriptionFactor	addTF_JL.tsv
+ZNF19	TranscriptionFactor	addTF_JL.tsv
+ZNF195	TranscriptionFactor	addTF_JL.tsv
+ZNF197	TranscriptionFactor	addTF_JL.tsv
+ZNF2	TranscriptionFactor	addTF_JL.tsv
+ZNF20	TranscriptionFactor	addTF_JL.tsv
+ZNF200	TranscriptionFactor	addTF_JL.tsv
+ZNF202	TranscriptionFactor	addTF_JL.tsv
+ZNF205	TranscriptionFactor	addTF_JL.tsv
+ZNF207	TranscriptionFactor	addTF_JL.tsv
+ZNF208	TranscriptionFactor	addTF_JL.tsv
+ZNF211	TranscriptionFactor	addTF_JL.tsv
+ZNF212	TranscriptionFactor	addTF_JL.tsv
+ZNF213	TranscriptionFactor	addTF_JL.tsv
+ZNF214	TranscriptionFactor	addTF_JL.tsv
+ZNF215	TranscriptionFactor	addTF_JL.tsv
+ZNF217	TranscriptionFactor, Oncogene	addTF_JL.tsv, OncoKBv20240704
+ZNF219	TranscriptionFactor	addTF_JL.tsv
+ZNF22	TranscriptionFactor	addTF_JL.tsv
+ZNF221	TranscriptionFactor	addTF_JL.tsv
+ZNF222	TranscriptionFactor	addTF_JL.tsv
+ZNF223	TranscriptionFactor	addTF_JL.tsv
+ZNF224	TranscriptionFactor	addTF_JL.tsv
+ZNF225	TranscriptionFactor	addTF_JL.tsv
+ZNF226	TranscriptionFactor	addTF_JL.tsv
+ZNF227	TranscriptionFactor	addTF_JL.tsv
+ZNF229	TranscriptionFactor	addTF_JL.tsv
+ZNF23	TranscriptionFactor	addTF_JL.tsv
+ZNF230	TranscriptionFactor	addTF_JL.tsv
+ZNF232	TranscriptionFactor	addTF_JL.tsv
+ZNF233	TranscriptionFactor	addTF_JL.tsv
+ZNF234	TranscriptionFactor	addTF_JL.tsv
+ZNF235	TranscriptionFactor	addTF_JL.tsv
+ZNF236	TranscriptionFactor	addTF_JL.tsv
+ZNF239	TranscriptionFactor	addTF_JL.tsv
+ZNF24	TranscriptionFactor	addTF_JL.tsv
+ZNF248	TranscriptionFactor	addTF_JL.tsv
+ZNF25	TranscriptionFactor	addTF_JL.tsv
+ZNF250	TranscriptionFactor	addTF_JL.tsv
+ZNF251	TranscriptionFactor	addTF_JL.tsv
+ZNF253	TranscriptionFactor	addTF_JL.tsv
+ZNF254	TranscriptionFactor	addTF_JL.tsv
+ZNF256	TranscriptionFactor	addTF_JL.tsv
+ZNF257	TranscriptionFactor	addTF_JL.tsv
+ZNF26	TranscriptionFactor	addTF_JL.tsv
+ZNF260	TranscriptionFactor	addTF_JL.tsv
+ZNF263	TranscriptionFactor	addTF_JL.tsv
+ZNF264	TranscriptionFactor	addTF_JL.tsv
+ZNF266	TranscriptionFactor	addTF_JL.tsv
+ZNF267	TranscriptionFactor	addTF_JL.tsv
+ZNF268	TranscriptionFactor	addTF_JL.tsv
+ZNF273	TranscriptionFactor	addTF_JL.tsv
+ZNF274	TranscriptionFactor	addTF_JL.tsv
+ZNF275	TranscriptionFactor	addTF_JL.tsv
+ZNF276	TranscriptionFactor	addTF_JL.tsv
+ZNF277	TranscriptionFactor	addTF_JL.tsv
+ZNF28	TranscriptionFactor	addTF_JL.tsv
+ZNF280A	TranscriptionFactor	addTF_JL.tsv
+ZNF280B	TranscriptionFactor	addTF_JL.tsv
+ZNF280C	TranscriptionFactor	addTF_JL.tsv
+ZNF280D	TranscriptionFactor	addTF_JL.tsv
+ZNF281	TranscriptionFactor	addTF_JL.tsv
+ZNF282	TranscriptionFactor	addTF_JL.tsv
+ZNF283	TranscriptionFactor	addTF_JL.tsv
+ZNF284	TranscriptionFactor	addTF_JL.tsv
+ZNF285	TranscriptionFactor	addTF_JL.tsv
+ZNF286A	TranscriptionFactor	addTF_JL.tsv
+ZNF286B	TranscriptionFactor	addTF_JL.tsv
+ZNF287	TranscriptionFactor	addTF_JL.tsv
+ZNF292	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZNF296	TranscriptionFactor	addTF_JL.tsv
+ZNF3	TranscriptionFactor	addTF_JL.tsv
+ZNF30	TranscriptionFactor	addTF_JL.tsv
+ZNF300	TranscriptionFactor	addTF_JL.tsv
+ZNF302	TranscriptionFactor	addTF_JL.tsv
+ZNF304	TranscriptionFactor	addTF_JL.tsv
+ZNF311	TranscriptionFactor	addTF_JL.tsv
+ZNF316	TranscriptionFactor	addTF_JL.tsv
+ZNF317	TranscriptionFactor	addTF_JL.tsv
+ZNF318	TranscriptionFactor	addTF_JL.tsv
+ZNF319	TranscriptionFactor	addTF_JL.tsv
+ZNF32	TranscriptionFactor	addTF_JL.tsv
+ZNF320	TranscriptionFactor	addTF_JL.tsv
+ZNF322	TranscriptionFactor	addTF_JL.tsv
+ZNF322P1	TranscriptionFactor	addTF_JL.tsv
+ZNF324	TranscriptionFactor	addTF_JL.tsv
+ZNF324B	TranscriptionFactor	addTF_JL.tsv
+ZNF326	TranscriptionFactor	addTF_JL.tsv
+ZNF329	TranscriptionFactor	addTF_JL.tsv
+ZNF331	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ZNF333	TranscriptionFactor	addTF_JL.tsv
+ZNF334	TranscriptionFactor	addTF_JL.tsv
+ZNF335	TranscriptionFactor	addTF_JL.tsv
+ZNF337	TranscriptionFactor	addTF_JL.tsv
+ZNF33A	TranscriptionFactor	addTF_JL.tsv
+ZNF33B	TranscriptionFactor	addTF_JL.tsv
+ZNF34	TranscriptionFactor	addTF_JL.tsv
+ZNF341	TranscriptionFactor	addTF_JL.tsv
+ZNF343	TranscriptionFactor	addTF_JL.tsv
+ZNF345	TranscriptionFactor	addTF_JL.tsv
+ZNF346	TranscriptionFactor	addTF_JL.tsv
+ZNF347	TranscriptionFactor	addTF_JL.tsv
+ZNF35	TranscriptionFactor	addTF_JL.tsv
+ZNF350	TranscriptionFactor	addTF_JL.tsv
+ZNF354A	TranscriptionFactor	addTF_JL.tsv
+ZNF354B	TranscriptionFactor	addTF_JL.tsv
+ZNF354C	TranscriptionFactor	addTF_JL.tsv
+ZNF358	TranscriptionFactor	addTF_JL.tsv
+ZNF362	TranscriptionFactor	addTF_JL.tsv
+ZNF365	TranscriptionFactor	addTF_JL.tsv
+ZNF366	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZNF367	TranscriptionFactor	addTF_JL.tsv
+ZNF37A	TranscriptionFactor	addTF_JL.tsv
+ZNF382	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZNF383	TranscriptionFactor	addTF_JL.tsv
+ZNF384	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ZNF385A	TranscriptionFactor	addTF_JL.tsv
+ZNF385B	TranscriptionFactor	addTF_JL.tsv
+ZNF385C	TranscriptionFactor	addTF_JL.tsv
+ZNF385D	TranscriptionFactor	addTF_JL.tsv
+ZNF391	TranscriptionFactor	addTF_JL.tsv
+ZNF394	TranscriptionFactor	addTF_JL.tsv
+ZNF395	TranscriptionFactor	addTF_JL.tsv
+ZNF396	TranscriptionFactor	addTF_JL.tsv
+ZNF397	TranscriptionFactor	addTF_JL.tsv
+ZNF398	TranscriptionFactor	addTF_JL.tsv
+ZNF404	TranscriptionFactor	addTF_JL.tsv
+ZNF407	TranscriptionFactor	addTF_JL.tsv
+ZNF408	TranscriptionFactor	addTF_JL.tsv
+ZNF41	TranscriptionFactor	addTF_JL.tsv
+ZNF410	TranscriptionFactor	addTF_JL.tsv
+ZNF414	TranscriptionFactor	addTF_JL.tsv
+ZNF415	TranscriptionFactor	addTF_JL.tsv
+ZNF416	TranscriptionFactor	addTF_JL.tsv
+ZNF417	TranscriptionFactor	addTF_JL.tsv
+ZNF418	TranscriptionFactor	addTF_JL.tsv
+ZNF419	TranscriptionFactor	addTF_JL.tsv
+ZNF420	TranscriptionFactor	addTF_JL.tsv
+ZNF423	TranscriptionFactor	addTF_JL.tsv
+ZNF425	TranscriptionFactor	addTF_JL.tsv
+ZNF426	TranscriptionFactor	addTF_JL.tsv
+ZNF428	TranscriptionFactor	addTF_JL.tsv
+ZNF429	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ZNF43	TranscriptionFactor	addTF_JL.tsv
+ZNF430	TranscriptionFactor	addTF_JL.tsv
+ZNF431	TranscriptionFactor	addTF_JL.tsv
+ZNF432	TranscriptionFactor	addTF_JL.tsv
+ZNF433	TranscriptionFactor	addTF_JL.tsv
+ZNF436	TranscriptionFactor	addTF_JL.tsv
+ZNF438	TranscriptionFactor	addTF_JL.tsv
+ZNF439	TranscriptionFactor	addTF_JL.tsv
+ZNF44	TranscriptionFactor	addTF_JL.tsv
+ZNF440	TranscriptionFactor	addTF_JL.tsv
+ZNF441	TranscriptionFactor	addTF_JL.tsv
+ZNF442	TranscriptionFactor	addTF_JL.tsv
+ZNF443	TranscriptionFactor	addTF_JL.tsv
+ZNF444	TranscriptionFactor	addTF_JL.tsv
+ZNF445	TranscriptionFactor	addTF_JL.tsv
+ZNF446	TranscriptionFactor	addTF_JL.tsv
+ZNF449	TranscriptionFactor	addTF_JL.tsv
+ZNF45	TranscriptionFactor	addTF_JL.tsv
+ZNF451	TranscriptionFactor	addTF_JL.tsv
+ZNF454	TranscriptionFactor	addTF_JL.tsv
+ZNF460	TranscriptionFactor	addTF_JL.tsv
+ZNF461	TranscriptionFactor	addTF_JL.tsv
+ZNF462	TranscriptionFactor	addTF_JL.tsv
+ZNF467	TranscriptionFactor	addTF_JL.tsv
+ZNF468	TranscriptionFactor	addTF_JL.tsv
+ZNF469	TranscriptionFactor	addTF_JL.tsv
+ZNF470	TranscriptionFactor	addTF_JL.tsv
+ZNF471	TranscriptionFactor	addTF_JL.tsv
+ZNF473	TranscriptionFactor	addTF_JL.tsv
+ZNF474	TranscriptionFactor	addTF_JL.tsv
+ZNF479	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ZNF48	TranscriptionFactor	addTF_JL.tsv
+ZNF480	TranscriptionFactor	addTF_JL.tsv
+ZNF483	TranscriptionFactor	addTF_JL.tsv
+ZNF484	TranscriptionFactor	addTF_JL.tsv
+ZNF485	TranscriptionFactor	addTF_JL.tsv
+ZNF486	TranscriptionFactor	addTF_JL.tsv
+ZNF487	TranscriptionFactor	addTF_JL.tsv
+ZNF488	TranscriptionFactor	addTF_JL.tsv
+ZNF490	TranscriptionFactor	addTF_JL.tsv
+ZNF491	TranscriptionFactor	addTF_JL.tsv
+ZNF492	TranscriptionFactor	addTF_JL.tsv
+ZNF493	TranscriptionFactor	addTF_JL.tsv
+ZNF496	TranscriptionFactor	addTF_JL.tsv
+ZNF497	TranscriptionFactor	addTF_JL.tsv
+ZNF500	TranscriptionFactor	addTF_JL.tsv
+ZNF501	TranscriptionFactor	addTF_JL.tsv
+ZNF502	TranscriptionFactor	addTF_JL.tsv
+ZNF503	TranscriptionFactor	addTF_JL.tsv
+ZNF506	TranscriptionFactor	addTF_JL.tsv
+ZNF507	TranscriptionFactor	addTF_JL.tsv
+ZNF510	TranscriptionFactor	addTF_JL.tsv
+ZNF511	TranscriptionFactor	addTF_JL.tsv
+ZNF512	TranscriptionFactor	addTF_JL.tsv
+ZNF512B	TranscriptionFactor	addTF_JL.tsv
+ZNF513	TranscriptionFactor	addTF_JL.tsv
+ZNF514	TranscriptionFactor	addTF_JL.tsv
+ZNF516	TranscriptionFactor	addTF_JL.tsv
+ZNF517	TranscriptionFactor	addTF_JL.tsv
+ZNF518A	TranscriptionFactor	addTF_JL.tsv
+ZNF518B	TranscriptionFactor	addTF_JL.tsv
+ZNF519	TranscriptionFactor	addTF_JL.tsv
+ZNF521	CosmicCensus, TranscriptionFactor	Census_allTue Sep 17 18_59_30 2019.tsv, addTF_JL.tsv
+ZNF524	TranscriptionFactor	addTF_JL.tsv
+ZNF525	TranscriptionFactor	addTF_JL.tsv
+ZNF526	TranscriptionFactor	addTF_JL.tsv
+ZNF527	TranscriptionFactor	addTF_JL.tsv
+ZNF528	TranscriptionFactor	addTF_JL.tsv
+ZNF529	TranscriptionFactor	addTF_JL.tsv
+ZNF530	TranscriptionFactor	addTF_JL.tsv
+ZNF532	TranscriptionFactor	addTF_JL.tsv
+ZNF534	TranscriptionFactor	addTF_JL.tsv
+ZNF536	TranscriptionFactor	addTF_JL.tsv
+ZNF540	TranscriptionFactor	addTF_JL.tsv
+ZNF541	TranscriptionFactor	addTF_JL.tsv
+ZNF543	TranscriptionFactor	addTF_JL.tsv
+ZNF544	TranscriptionFactor	addTF_JL.tsv
+ZNF546	TranscriptionFactor	addTF_JL.tsv
+ZNF547	TranscriptionFactor	addTF_JL.tsv
+ZNF548	TranscriptionFactor	addTF_JL.tsv
+ZNF549	TranscriptionFactor	addTF_JL.tsv
+ZNF550	TranscriptionFactor	addTF_JL.tsv
+ZNF551	TranscriptionFactor	addTF_JL.tsv
+ZNF552	TranscriptionFactor	addTF_JL.tsv
+ZNF554	TranscriptionFactor	addTF_JL.tsv
+ZNF555	TranscriptionFactor	addTF_JL.tsv
+ZNF556	TranscriptionFactor	addTF_JL.tsv
+ZNF557	TranscriptionFactor	addTF_JL.tsv
+ZNF558	TranscriptionFactor	addTF_JL.tsv
+ZNF559	TranscriptionFactor	addTF_JL.tsv
+ZNF560	TranscriptionFactor	addTF_JL.tsv
+ZNF561	TranscriptionFactor	addTF_JL.tsv
+ZNF562	TranscriptionFactor	addTF_JL.tsv
+ZNF563	TranscriptionFactor	addTF_JL.tsv
+ZNF564	TranscriptionFactor	addTF_JL.tsv
+ZNF565	TranscriptionFactor	addTF_JL.tsv
+ZNF566	TranscriptionFactor	addTF_JL.tsv
+ZNF567	TranscriptionFactor	addTF_JL.tsv
+ZNF568	TranscriptionFactor	addTF_JL.tsv
+ZNF569	TranscriptionFactor	addTF_JL.tsv
+ZNF57	TranscriptionFactor	addTF_JL.tsv
+ZNF570	TranscriptionFactor	addTF_JL.tsv
+ZNF571	TranscriptionFactor	addTF_JL.tsv
+ZNF572	TranscriptionFactor	addTF_JL.tsv
+ZNF573	TranscriptionFactor	addTF_JL.tsv
+ZNF574	TranscriptionFactor	addTF_JL.tsv
+ZNF575	TranscriptionFactor	addTF_JL.tsv
+ZNF576	TranscriptionFactor	addTF_JL.tsv
+ZNF577	TranscriptionFactor	addTF_JL.tsv
+ZNF578	TranscriptionFactor	addTF_JL.tsv
+ZNF579	TranscriptionFactor	addTF_JL.tsv
+ZNF580	TranscriptionFactor	addTF_JL.tsv
+ZNF581	TranscriptionFactor	addTF_JL.tsv
+ZNF582	TranscriptionFactor	addTF_JL.tsv
+ZNF583	TranscriptionFactor	addTF_JL.tsv
+ZNF584	TranscriptionFactor	addTF_JL.tsv
+ZNF585A	TranscriptionFactor	addTF_JL.tsv
+ZNF585B	TranscriptionFactor	addTF_JL.tsv
+ZNF586	TranscriptionFactor	addTF_JL.tsv
+ZNF587	TranscriptionFactor	addTF_JL.tsv
+ZNF587B	TranscriptionFactor	addTF_JL.tsv
+ZNF589	TranscriptionFactor	addTF_JL.tsv
+ZNF592	TranscriptionFactor	addTF_JL.tsv
+ZNF594	TranscriptionFactor	addTF_JL.tsv
+ZNF595	TranscriptionFactor	addTF_JL.tsv
+ZNF596	TranscriptionFactor	addTF_JL.tsv
+ZNF597	TranscriptionFactor	addTF_JL.tsv
+ZNF598	TranscriptionFactor	addTF_JL.tsv
+ZNF599	TranscriptionFactor	addTF_JL.tsv
+ZNF600	TranscriptionFactor	addTF_JL.tsv
+ZNF605	TranscriptionFactor	addTF_JL.tsv
+ZNF606	TranscriptionFactor	addTF_JL.tsv
+ZNF607	TranscriptionFactor	addTF_JL.tsv
+ZNF608	TranscriptionFactor	addTF_JL.tsv
+ZNF609	TranscriptionFactor	addTF_JL.tsv
+ZNF610	TranscriptionFactor	addTF_JL.tsv
+ZNF611	TranscriptionFactor	addTF_JL.tsv
+ZNF613	TranscriptionFactor	addTF_JL.tsv
+ZNF614	TranscriptionFactor	addTF_JL.tsv
+ZNF615	TranscriptionFactor	addTF_JL.tsv
+ZNF616	TranscriptionFactor	addTF_JL.tsv
+ZNF618	TranscriptionFactor	addTF_JL.tsv
+ZNF619	TranscriptionFactor	addTF_JL.tsv
+ZNF620	TranscriptionFactor	addTF_JL.tsv
+ZNF621	TranscriptionFactor	addTF_JL.tsv
+ZNF623	TranscriptionFactor	addTF_JL.tsv
+ZNF624	TranscriptionFactor	addTF_JL.tsv
+ZNF625	TranscriptionFactor	addTF_JL.tsv
+ZNF626	TranscriptionFactor	addTF_JL.tsv
+ZNF627	TranscriptionFactor	addTF_JL.tsv
+ZNF628	TranscriptionFactor	addTF_JL.tsv
+ZNF629	TranscriptionFactor	addTF_JL.tsv
+ZNF630	TranscriptionFactor	addTF_JL.tsv
+ZNF639	TranscriptionFactor	addTF_JL.tsv
+ZNF641	TranscriptionFactor	addTF_JL.tsv
+ZNF644	TranscriptionFactor	addTF_JL.tsv
+ZNF645	TranscriptionFactor	addTF_JL.tsv
+ZNF646	TranscriptionFactor	addTF_JL.tsv
+ZNF648	TranscriptionFactor	addTF_JL.tsv
+ZNF649	TranscriptionFactor	addTF_JL.tsv
+ZNF652	TranscriptionFactor	addTF_JL.tsv
+ZNF653	TranscriptionFactor	addTF_JL.tsv
+ZNF654	TranscriptionFactor	addTF_JL.tsv
+ZNF655	TranscriptionFactor	addTF_JL.tsv
+ZNF658	TranscriptionFactor	addTF_JL.tsv
+ZNF66	TranscriptionFactor	addTF_JL.tsv
+ZNF660	TranscriptionFactor	addTF_JL.tsv
+ZNF662	TranscriptionFactor	addTF_JL.tsv
+ZNF664	TranscriptionFactor	addTF_JL.tsv
+ZNF665	TranscriptionFactor	addTF_JL.tsv
+ZNF667	TranscriptionFactor	addTF_JL.tsv
+ZNF668	TumorSuppressorGene, TranscriptionFactor	TumorSuppressorGene.txt, addTF_JL.tsv
+ZNF669	TranscriptionFactor	addTF_JL.tsv
+ZNF670	TranscriptionFactor	addTF_JL.tsv
+ZNF671	TranscriptionFactor	addTF_JL.tsv
+ZNF672	TranscriptionFactor	addTF_JL.tsv
+ZNF674	TranscriptionFactor	addTF_JL.tsv
+ZNF675	TranscriptionFactor	addTF_JL.tsv
+ZNF676	TranscriptionFactor	addTF_JL.tsv
+ZNF677	TranscriptionFactor	addTF_JL.tsv
+ZNF678	TranscriptionFactor	addTF_JL.tsv
+ZNF679	TranscriptionFactor	addTF_JL.tsv
+ZNF680	TranscriptionFactor	addTF_JL.tsv
+ZNF681	TranscriptionFactor	addTF_JL.tsv
+ZNF682	TranscriptionFactor	addTF_JL.tsv
+ZNF683	TranscriptionFactor	addTF_JL.tsv
+ZNF684	TranscriptionFactor	addTF_JL.tsv
+ZNF687	TranscriptionFactor	addTF_JL.tsv
+ZNF688	TranscriptionFactor	addTF_JL.tsv
+ZNF689	TranscriptionFactor	addTF_JL.tsv
+ZNF69	TranscriptionFactor	addTF_JL.tsv
+ZNF691	TranscriptionFactor	addTF_JL.tsv
+ZNF692	TranscriptionFactor	addTF_JL.tsv
+ZNF695	TranscriptionFactor	addTF_JL.tsv
+ZNF696	TranscriptionFactor	addTF_JL.tsv
+ZNF697	TranscriptionFactor	addTF_JL.tsv
+ZNF699	TranscriptionFactor	addTF_JL.tsv
+ZNF7	TranscriptionFactor	addTF_JL.tsv
+ZNF70	TranscriptionFactor	addTF_JL.tsv
+ZNF700	TranscriptionFactor	addTF_JL.tsv
+ZNF701	TranscriptionFactor	addTF_JL.tsv
+ZNF703	TranscriptionFactor	addTF_JL.tsv
+ZNF704	TranscriptionFactor	addTF_JL.tsv
+ZNF705A	TranscriptionFactor	addTF_JL.tsv
+ZNF705B	TranscriptionFactor	addTF_JL.tsv
+ZNF705D	TranscriptionFactor	addTF_JL.tsv
+ZNF705E	TranscriptionFactor	addTF_JL.tsv
+ZNF705EP	TranscriptionFactor	addTF_JL.tsv
+ZNF705G	TranscriptionFactor	addTF_JL.tsv
+ZNF706	TranscriptionFactor	addTF_JL.tsv
+ZNF707	TranscriptionFactor	addTF_JL.tsv
+ZNF708	TranscriptionFactor	addTF_JL.tsv
+ZNF709	TranscriptionFactor	addTF_JL.tsv
+ZNF71	TranscriptionFactor	addTF_JL.tsv
+ZNF710	TranscriptionFactor	addTF_JL.tsv
+ZNF711	TranscriptionFactor	addTF_JL.tsv
+ZNF713	TranscriptionFactor	addTF_JL.tsv
+ZNF714	TranscriptionFactor	addTF_JL.tsv
+ZNF716	TranscriptionFactor	addTF_JL.tsv
+ZNF717	TranscriptionFactor	addTF_JL.tsv
+ZNF718	TranscriptionFactor	addTF_JL.tsv
+ZNF721	TranscriptionFactor	addTF_JL.tsv
+ZNF724	TranscriptionFactor	addTF_JL.tsv
+ZNF726	TranscriptionFactor	addTF_JL.tsv
+ZNF727	TranscriptionFactor	addTF_JL.tsv
+ZNF728	TranscriptionFactor	addTF_JL.tsv
+ZNF729	TranscriptionFactor	addTF_JL.tsv
+ZNF730	TranscriptionFactor	addTF_JL.tsv
+ZNF732	TranscriptionFactor	addTF_JL.tsv
+ZNF735	TranscriptionFactor	addTF_JL.tsv
+ZNF736	TranscriptionFactor	addTF_JL.tsv
+ZNF737	TranscriptionFactor	addTF_JL.tsv
+ZNF74	TranscriptionFactor	addTF_JL.tsv
+ZNF740	TranscriptionFactor	addTF_JL.tsv
+ZNF746	TranscriptionFactor	addTF_JL.tsv
+ZNF747	TranscriptionFactor	addTF_JL.tsv
+ZNF749	TranscriptionFactor	addTF_JL.tsv
+ZNF750	TranscriptionFactor, TumorSuppressorGene	addTF_JL.tsv, OncoKBv20240704
+ZNF75A	TranscriptionFactor	addTF_JL.tsv
+ZNF75D	TranscriptionFactor	addTF_JL.tsv
+ZNF76	TranscriptionFactor	addTF_JL.tsv
+ZNF761	TranscriptionFactor	addTF_JL.tsv
+ZNF763	TranscriptionFactor	addTF_JL.tsv
+ZNF764	TranscriptionFactor	addTF_JL.tsv
+ZNF765	TranscriptionFactor	addTF_JL.tsv
+ZNF766	TranscriptionFactor	addTF_JL.tsv
+ZNF768	TranscriptionFactor	addTF_JL.tsv
+ZNF77	TranscriptionFactor	addTF_JL.tsv
+ZNF770	TranscriptionFactor	addTF_JL.tsv
+ZNF771	TranscriptionFactor	addTF_JL.tsv
+ZNF772	TranscriptionFactor	addTF_JL.tsv
+ZNF773	TranscriptionFactor	addTF_JL.tsv
+ZNF774	TranscriptionFactor	addTF_JL.tsv
+ZNF775	TranscriptionFactor	addTF_JL.tsv
+ZNF776	TranscriptionFactor	addTF_JL.tsv
+ZNF777	TranscriptionFactor	addTF_JL.tsv
+ZNF778	TranscriptionFactor	addTF_JL.tsv
+ZNF780A	TranscriptionFactor	addTF_JL.tsv
+ZNF780B	TranscriptionFactor	addTF_JL.tsv
+ZNF781	TranscriptionFactor	addTF_JL.tsv
+ZNF782	TranscriptionFactor	addTF_JL.tsv
+ZNF783	TranscriptionFactor	addTF_JL.tsv
+ZNF784	TranscriptionFactor	addTF_JL.tsv
+ZNF785	TranscriptionFactor	addTF_JL.tsv
+ZNF786	TranscriptionFactor	addTF_JL.tsv
+ZNF787	TranscriptionFactor	addTF_JL.tsv
+ZNF788	TranscriptionFactor	addTF_JL.tsv
+ZNF788P	TranscriptionFactor	addTF_JL.tsv
+ZNF789	TranscriptionFactor	addTF_JL.tsv
+ZNF79	TranscriptionFactor	addTF_JL.tsv
+ZNF790	TranscriptionFactor	addTF_JL.tsv
+ZNF791	TranscriptionFactor	addTF_JL.tsv
+ZNF792	TranscriptionFactor	addTF_JL.tsv
+ZNF793	TranscriptionFactor	addTF_JL.tsv
+ZNF799	TranscriptionFactor	addTF_JL.tsv
+ZNF8	TranscriptionFactor	addTF_JL.tsv
+ZNF80	TranscriptionFactor	addTF_JL.tsv
+ZNF800	TranscriptionFactor	addTF_JL.tsv
+ZNF804A	TranscriptionFactor	addTF_JL.tsv
+ZNF804B	TranscriptionFactor	addTF_JL.tsv
+ZNF805	TranscriptionFactor	addTF_JL.tsv
+ZNF808	TranscriptionFactor	addTF_JL.tsv
+ZNF81	TranscriptionFactor	addTF_JL.tsv
+ZNF813	TranscriptionFactor	addTF_JL.tsv
+ZNF814	TranscriptionFactor	addTF_JL.tsv
+ZNF816	TranscriptionFactor	addTF_JL.tsv
+ZNF821	TranscriptionFactor	addTF_JL.tsv
+ZNF823	TranscriptionFactor	addTF_JL.tsv
+ZNF827	TranscriptionFactor	addTF_JL.tsv
+ZNF829	TranscriptionFactor	addTF_JL.tsv
+ZNF83	TranscriptionFactor	addTF_JL.tsv
+ZNF830	TranscriptionFactor	addTF_JL.tsv
+ZNF831	TranscriptionFactor	addTF_JL.tsv
+ZNF835	TranscriptionFactor	addTF_JL.tsv
+ZNF836	TranscriptionFactor	addTF_JL.tsv
+ZNF837	TranscriptionFactor	addTF_JL.tsv
+ZNF84	TranscriptionFactor	addTF_JL.tsv
+ZNF841	TranscriptionFactor	addTF_JL.tsv
+ZNF843	TranscriptionFactor	addTF_JL.tsv
+ZNF844	TranscriptionFactor	addTF_JL.tsv
+ZNF845	TranscriptionFactor	addTF_JL.tsv
+ZNF846	TranscriptionFactor	addTF_JL.tsv
+ZNF85	TranscriptionFactor	addTF_JL.tsv
+ZNF850	TranscriptionFactor	addTF_JL.tsv
+ZNF852	TranscriptionFactor	addTF_JL.tsv
+ZNF853	TranscriptionFactor	addTF_JL.tsv
+ZNF860	TranscriptionFactor	addTF_JL.tsv
+ZNF865	TranscriptionFactor	addTF_JL.tsv
+ZNF875	TranscriptionFactor	addTF_JL.tsv
+ZNF878	TranscriptionFactor	addTF_JL.tsv
+ZNF879	TranscriptionFactor	addTF_JL.tsv
+ZNF880	TranscriptionFactor	addTF_JL.tsv
+ZNF883	TranscriptionFactor	addTF_JL.tsv
+ZNF888	TranscriptionFactor	addTF_JL.tsv
+ZNF891	TranscriptionFactor	addTF_JL.tsv
+ZNF90	TranscriptionFactor	addTF_JL.tsv
+ZNF91	TranscriptionFactor	addTF_JL.tsv
+ZNF92	TranscriptionFactor	addTF_JL.tsv
+ZNF93	TranscriptionFactor	addTF_JL.tsv
+ZNF98	TranscriptionFactor	addTF_JL.tsv
+ZNF99	TranscriptionFactor	addTF_JL.tsv
+ZNRF3	CosmicCensus, TumorSuppressorGene	Census_allTue Sep 17 18_59_30 2019.tsv, OncoKBv20240704
+ZRSR2	CosmicCensus	Census_allTue Sep 17 18_59_30 2019.tsv
+ZSCAN1	TranscriptionFactor	addTF_JL.tsv
+ZSCAN10	TranscriptionFactor	addTF_JL.tsv
+ZSCAN12	TranscriptionFactor	addTF_JL.tsv
+ZSCAN16	TranscriptionFactor	addTF_JL.tsv
+ZSCAN18	TranscriptionFactor	addTF_JL.tsv
+ZSCAN2	TranscriptionFactor	addTF_JL.tsv
+ZSCAN20	TranscriptionFactor	addTF_JL.tsv
+ZSCAN21	TranscriptionFactor	addTF_JL.tsv
+ZSCAN22	TranscriptionFactor	addTF_JL.tsv
+ZSCAN23	TranscriptionFactor	addTF_JL.tsv
+ZSCAN25	TranscriptionFactor	addTF_JL.tsv
+ZSCAN26	TranscriptionFactor	addTF_JL.tsv
+ZSCAN29	TranscriptionFactor	addTF_JL.tsv
+ZSCAN30	TranscriptionFactor	addTF_JL.tsv
+ZSCAN31	TranscriptionFactor	addTF_JL.tsv
+ZSCAN32	TranscriptionFactor	addTF_JL.tsv
+ZSCAN4	TranscriptionFactor	addTF_JL.tsv
+ZSCAN5A	TranscriptionFactor	addTF_JL.tsv
+ZSCAN5B	TranscriptionFactor	addTF_JL.tsv
+ZSCAN5C	TranscriptionFactor	addTF_JL.tsv
+ZSCAN9	TranscriptionFactor	addTF_JL.tsv
+ZUFSP	TranscriptionFactor	addTF_JL.tsv
+ZUP1	TranscriptionFactor	addTF_JL.tsv
+ZXDA	TranscriptionFactor	addTF_JL.tsv
+ZXDB	TranscriptionFactor	addTF_JL.tsv
+ZXDC	TranscriptionFactor	addTF_JL.tsv
+ZYX	TumorSuppressorGene	TumorSuppressorGene.txt
+ZZZ3	TranscriptionFactor	addTF_JL.tsv
+caMLCK	Kinase	Kincat_Hsap.08.02.txt
+eEF2K	Kinase	Kincat_Hsap.08.02.txt
+p38a	Kinase	Kincat_Hsap.08.02.txt
+p38b	Kinase	Kincat_Hsap.08.02.txt
+p38d	Kinase	Kincat_Hsap.08.02.txt
+p38g	Kinase	Kincat_Hsap.08.02.txt
+p70S6K	Kinase	Kincat_Hsap.08.02.txt
+p70S6Kb	Kinase	Kincat_Hsap.08.02.txt
+p70S6Kps1	Kinase	Kincat_Hsap.08.02.txt
+p70S6Kps2	Kinase	Kincat_Hsap.08.02.txt
+skMLCK	Kinase	Kincat_Hsap.08.02.txt
+smMLCK	Kinase	Kincat_Hsap.08.02.txt


### PR DESCRIPTION
Using the below code, deduplicated the genes per https://github.com/d3b-center/OpenPedCan-analysis/issues/558.
Removes `OncoKBv20240704` from file when not TSG/Oncogene
Removes `classification` column from final output, as that was from the oncokb file.
 

```r
genelist <- "annoFuseData/inst/extdata/genelistreference.txt"
dupgenes <- genelist[duplicated(genelist$Gene_Symbol),"Gene_Symbol"]

genelist_dedup <- genelist %>%
  group_by(Gene_Symbol, classification) %>%
  mutate(file = case_when(is.na(classification) ~ gsub(", OncoKBv20240704", "", file), 
                          TRUE ~ file)) %>%
  reframe(type = paste(unique(trimws(unlist(strsplit(type, ", ")))), collapse = ", "),
          file = paste(unique(trimws(unlist(strsplit(file, ", ")))), collapse = ", ")) %>%
  select(-classification) %>%
  write_tsv("~/Documents/GitHub/annoFuseData/inst/extdata/genelistreference.txt")

> length(dupgenes$Gene_Symbol) == nrow(genelist)-nrow(genelist_dedup)
[1] TRUE

```